### PR TITLE
Updating requirements to point to public cached-property

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pytz==2019.2
 numpy==1.15.1
 pytest==4.1.1
 pytest-cov==2.6.1
-git+ssh://git@github.com/BEL-CO/cached-property.git@v1.0.0
+git+ssh://git@github.com/BEL-Public/cached-property.git@v1.0.1


### PR DESCRIPTION
This PR updates the cached property referred to in Requirements.txt to be the Apached Licensed version available from BEL's public repository