### PR TITLE
Small cleanup of setup.py to match up with pypi's best practices.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,21 @@
-from setuptools import setup
+import setuptools
 
-setup(
+setuptools.setup(
     name='mffpy',
     version='0.3.0',
-    packages=['mffpy'],
+    packages=setuptools.find_packages(),
     scripts=['./bin/mff2mfz.py'],
     author='Justus Schwabedal, Wayne Manselle',
     author_email='jschwabedal@belco.tech, wayne.manselle@belco.tech',
     maintainer='Justus Schwabedal',
     maintainer_email='jschwabedal@belco.tech',
+    description="Reader and Writer for Philips' MFF file format.",
     long_description=open('README.md').read(),
+    long_description_content_type="text/markdown",
     include_package_data=True,
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: Apache License :: Version 2.0",
+        "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
     python_requires='>=3.6',


### PR DESCRIPTION
Tested pushing up to the test pypi index from this direction as well.

`$ pip install --index-url https://test.pypi.org/simple/ mffpy` for a quick installation test.