### PR TITLE
Fix 17 - Compress EEG data when exporting MFFs into JSON files

### DIFF
--- a/mffpy/__init__.py
+++ b/mffpy/__init__.py
@@ -16,4 +16,4 @@ from .xml_files import XML  # noqa: F401
 from .reader import Reader  # noqa: F401
 from .writer import Writer  # noqa: F401
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name='mffpy',
-    version='0.4.1',
+    version='0.4.2',
     packages=setuptools.find_packages(),
     scripts=['./bin/mff2json.py', './bin/mff2mfz.py'],
     author='Justus Schwabedal, Wayne Manselle',


### PR DESCRIPTION
This pull request addresses Issue #17 and fixes Issue #20 .

Main changes:

- Now, EEG data is compressed using a base64 encoding scheme.
- Now, EEG data is retrieved from the `signal1.bin` file specifying the begin and end time of each segment instead of specifying epochs. This is due to the fact that there are some segmented MFF files in which segments and epochs do not match at all.