### PR TITLE
Fix 22 - Set encoding of B64 strings in Reader to UTF-8

### DIFF
--- a/mffpy/__init__.py
+++ b/mffpy/__init__.py
@@ -16,4 +16,4 @@ from .xml_files import XML  # noqa: F401
 from .reader import Reader  # noqa: F401
 from .writer import Writer  # noqa: F401
 
-__version__ = "0.4.2"
+__version__ = "0.5.0"

--- a/mffpy/reader.py
+++ b/mffpy/reader.py
@@ -290,7 +290,7 @@ class Reader:
                                 eeg, start_time = samples['EEG']
                                 # Insert an EEG data field into each segment.
                                 # Compress EEG data using a base64 encoding scheme.
-                                segment['eegData'] = str(b64encode(object_to_bytes(eeg.tolist())))
+                                segment['eegData'] = str(b64encode(object_to_bytes(eeg.tolist())), encoding='utf-8')
 
                     mff_content[obj.xml_root_tag] = content
                 except KeyError as e:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name='mffpy',
-    version='0.4.2',
+    version='0.5.0',
     packages=setuptools.find_packages(),
     scripts=['./bin/mff2json.py', './bin/mff2mfz.py'],
     author='Justus Schwabedal, Wayne Manselle',


### PR DESCRIPTION
This commit fixes Issue #22 and increments the module's version number to 0.5.0.

- We now explicitly encode B64 strings as UTF-8 strings.