### PR TITLE
Fix default for property Epoch.name

### DIFF
--- a/mffpy/epoch.py
+++ b/mffpy/epoch.py
@@ -24,11 +24,10 @@ class Epoch:
     """
 
     _s_per_us = 10**-6
-    default_name = 'epoch'
+    name = 'epoch'
 
     def __init__(self, beginTime, endTime, firstBlock,
-                 lastBlock, name=default_name):
-        self.name = name
+                 lastBlock):
         self.beginTime = beginTime
         self.endTime = endTime
         self.firstBlock = firstBlock
@@ -37,14 +36,6 @@ class Epoch:
     def add_block(self, duration):
         self.lastBlock += 1
         self.endTime += duration
-
-    @property
-    def name(self):
-        return self._name
-
-    @name.setter
-    def name(self, name):
-        self._name = name
 
     @property
     def t0(self):


### PR DESCRIPTION
@ephathaway unfortunately your changes didn't do the trick.  To test the change-in-default functionality in your branch, I used the script:

```python
from mffpy.epoch import Epoch
Epoch.default_name = "My new default"
print(Epoch(0, 0, 0, 0))
```

I added some changes in this PR that works if you do:

```python
from mffpy.epoch import Epoch
Epoch.name = "My new default"
print(Epoch(0, 0, 0, 0))
```

Sorry for being very peculiar on this, but we want to get it right in our publicly exposed repository.  Please merge the changes into your branch if you like these and I'll approve your pull request.