### PR TITLE
Parse history.xml Files

### DIFF
--- a/mffpy/reader.py
+++ b/mffpy/reader.py
@@ -61,6 +61,25 @@ class Reader:
         self.directory = get_directory(filename)
 
     @cached_property
+    def mff_flavor(self) -> str:
+        """
+        ```python
+        Reader.mff_flavor
+        ```
+        return flavor of the MFF
+
+        Return string value with the flavor of the MFF either, 'continuous',
+        'segmented', or 'averaged'. This is determined from the entries in
+        the `history.xml` file. If no `history.xml` return 'continuous'.
+        """
+        try:
+            with self.directory.filepointer('history') as fp:
+                history = XML.from_file(fp)
+                return history.mff_flavor()
+        except ValueError:
+            return 'continuous'
+
+    @cached_property
     def categories(self) -> Categories:
         """
         ```python
@@ -307,7 +326,7 @@ class Reader:
         # Root tags corresponding to available XMLType sub-classes
         xml_root_tags = ['fileInfo', 'dataInfo', 'patient', 'sensorLayout',
                          'coordinates', 'epochs', 'eventTrack', 'categories',
-                         'dipoleSet']
+                         'dipoleSet', 'historyEntries']
         # Create the dictionary that will be returned by this function
         mff_content = {tag: {} for tag in xml_root_tags}
 

--- a/mffpy/reader.py
+++ b/mffpy/reader.py
@@ -61,10 +61,10 @@ class Reader:
         self.directory = get_directory(filename)
 
     @cached_property
-    def mff_flavor(self) -> str:
+    def flavor(self) -> str:
         """
         ```python
-        Reader.mff_flavor
+        Reader.flavor
         ```
         return flavor of the MFF
 
@@ -72,11 +72,11 @@ class Reader:
         'segmented', or 'averaged'. This is determined from the entries in
         the `history.xml` file. If no `history.xml` return 'continuous'.
         """
-        try:
+        if 'history.xml' in self.directory.listdir():
             with self.directory.filepointer('history') as fp:
                 history = XML.from_file(fp)
                 return history.mff_flavor()
-        except ValueError:
+        else:
             return 'continuous'
 
     @cached_property
@@ -324,9 +324,7 @@ class Reader:
         """
 
         # Root tags corresponding to available XMLType sub-classes
-        xml_root_tags = ['fileInfo', 'dataInfo', 'patient', 'sensorLayout',
-                         'coordinates', 'epochs', 'eventTrack', 'categories',
-                         'dipoleSet', 'historyEntries']
+        xml_root_tags = xml_files.XMLType.xml_root_tags()
         # Create the dictionary that will be returned by this function
         mff_content = {tag: {} for tag in xml_root_tags}
 

--- a/mffpy/tests/test_reader.py
+++ b/mffpy/tests/test_reader.py
@@ -204,8 +204,8 @@ def test_epochs_averaged(mffpath_4, idx, name, expected):
         epochs[{idx}][{key}] = {val} [should be {exp}]"""
 
 
-def test_mff_flavor(mffpath, mffpath_2, mffpath_3, mffpath_4):
-    assert Reader(mffpath).mff_flavor == 'continuous'
-    assert Reader(mffpath_2).mff_flavor == 'segmented'
-    assert Reader(mffpath_3).mff_flavor == 'continuous'
-    assert Reader(mffpath_4).mff_flavor == 'averaged'
+def test_flavor(mffpath, mffpath_2, mffpath_3, mffpath_4):
+    assert Reader(mffpath).flavor == 'continuous'
+    assert Reader(mffpath_2).flavor == 'segmented'
+    assert Reader(mffpath_3).flavor == 'continuous'
+    assert Reader(mffpath_4).flavor == 'averaged'

--- a/mffpy/tests/test_reader.py
+++ b/mffpy/tests/test_reader.py
@@ -202,3 +202,10 @@ def test_epochs_averaged(mffpath_4, idx, name, expected):
         val = getattr(read_epoch, key)
         assert val == exp, f"""
         epochs[{idx}][{key}] = {val} [should be {exp}]"""
+
+
+def test_mff_flavor(mffpath, mffpath_2, mffpath_3, mffpath_4):
+    assert Reader(mffpath).mff_flavor == 'continuous'
+    assert Reader(mffpath_2).mff_flavor == 'segmented'
+    assert Reader(mffpath_3).mff_flavor == 'continuous'
+    assert Reader(mffpath_4).mff_flavor == 'averaged'

--- a/mffpy/tests/test_xml_files.py
+++ b/mffpy/tests/test_xml_files.py
@@ -39,7 +39,7 @@ to be tested.  The files parsed are located in `mff_path`.
 @pytest.fixture
 def file_info():
     ans = join(mff_path, 'info.xml')
-    assert exists(ans), ans
+    assert exists(ans), f"Not found: '{ans}'"
     return XML.from_file(ans)
 
 
@@ -47,7 +47,7 @@ def file_info():
 @pytest.fixture
 def data_info():
     ans = join(mff_path, 'info1.xml')
-    assert exists(ans), ans
+    assert exists(ans), f"Not found: '{ans}'"
     return XML.from_file(ans)
 
 
@@ -55,63 +55,63 @@ def data_info():
 @pytest.fixture
 def data_info2():
     ans = join(examples_path, 'example_3.mff/info2.xml')
-    assert exists(ans), ans
+    assert exists(ans), f"Not found: '{ans}'"
     return XML.from_file(ans)
 
 
 @pytest.fixture
 def patient():
     ans = join(mff_path, 'subject.xml')
-    assert exists(ans), ans
+    assert exists(ans), f"Not found: '{ans}'"
     return XML.from_file(ans)
 
 
 @pytest.fixture
 def sensor_layout():
     ans = join(mff_path, 'sensorLayout.xml')
-    assert exists(ans), ans
+    assert exists(ans), f"Not found: '{ans}'"
     return XML.from_file(ans)
 
 
 @pytest.fixture
 def coordinates():
     ans = join(mff_path, 'coordinates.xml')
-    assert exists(ans), ans
+    assert exists(ans), f"Not found: '{ans}'"
     return XML.from_file(ans)
 
 
 @pytest.fixture
 def epochs():
     ans = join(mff_path, 'epochs.xml')
-    assert exists(ans), ans
+    assert exists(ans), f"Not found: '{ans}'"
     return XML.from_file(ans)
 
 
 @pytest.fixture
 def event_track():
     ans = join(mff_path, 'Events_ECI.xml')
-    assert exists(ans), ans
+    assert exists(ans), f"Not found: '{ans}'"
     return XML.from_file(ans)
 
 
 @pytest.fixture
 def categories():
     ans = join(mff_path, 'categories.xml')
-    assert exists(ans), ans
+    assert exists(ans), f"Not found: '{ans}'"
     return XML.from_file(ans)
 
 
 @pytest.fixture
 def dipoleSet():
     ans = join(mff_path, 'dipoleSet.xml')
-    assert exists(ans), ans
+    assert exists(ans), f"Not found: '{ans}'"
     return XML.from_file(ans)
 
 
 @pytest.fixture
 def history():
-    ans = join(examples_path, 'example_2.mff/history.xml')
-    assert exists(ans), ans
+    ans = join(examples_path, 'example_2.mff', 'history.xml')
+    assert exists(ans), f"Not found: '{ans}'"
     return XML.from_file(ans)
 
 

--- a/mffpy/xml_files.py
+++ b/mffpy/xml_files.py
@@ -95,6 +95,11 @@ class XMLType(type):
             'namespace': T._xmlns[1:-1]
         }
 
+    @classmethod
+    def xml_root_tags(cls):
+        """return list of root tags of supported xml files"""
+        return list(cls._tag_registry.keys())
+
 
 class XML(metaclass=XMLType):
 
@@ -1167,13 +1172,10 @@ class History(XML):
     def mff_flavor(self) -> str:
         """return either 'continuous', 'segmented',
         or 'averaged' representing mff flavor"""
-        segmented = False
-        for entry in self.entries:
-            if entry['method'] == 'Segmentation':
-                segmented = True
-            if entry['method'] == 'Averaging':
-                return 'averaged'
-        if segmented:
+        methods = [entry['method'].lower() for entry in self.entries]
+        if 'averaging' in methods:
+            return 'averaged'
+        elif 'segmentation' in methods:
             return 'segmented'
         else:
             return 'continuous'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name='mffpy',
-    version='0.5.3',
+    version='0.5.4',
     packages=setuptools.find_packages(),
     scripts=['./bin/mff2json.py', './bin/mff2mfz.py'],
     author='Justus Schwabedal, Wayne Manselle',


### PR DESCRIPTION
Here we add class `History` for parsing history.xml files in MFF directory. These files contain info on the different tools that have been applied to the MFF (filtering, averaging, etc.)

We now have a way of determining whether an MFF is continuous, segmented, or averaged. We add function `Reader.mff_flavor` to return this info. I am pretty convinced that the history.xml (or lack there of) is the most sure-fire way of deriving this info, but I am open to other proposals.