### PR TITLE
FIX: support additional data types for event keys

### DIFF
--- a/mffpy/xml_files.py
+++ b/mffpy/xml_files.py
@@ -696,7 +696,9 @@ class EventTrack(XML):
         }
         self._key_type_converter = {
             'short': np.int16,
+            'long': np.int64,
             'string': str,
+            'TEXT': str,
         }
 
     @cached_property

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name='mffpy',
-    version='0.5.4',
+    version='0.5.5',
     packages=setuptools.find_packages(),
     scripts=['./bin/mff2json.py', './bin/mff2mfz.py'],
     author='Justus Schwabedal, Wayne Manselle',


### PR DESCRIPTION
I fixed a small bug in parsing events XML files. Sometimes in events files we have these various "keys" associated with events. They contain data of different types, which can be 'short', 'long', 'string', or 'TEXT' (that we know of). I added 'long' and 'TEXT' datatypes to the type converted dictionary. It seems like "long" means int64 in most contexts, so I went with that.

```
    <event>
        <beginTime>2018-10-24T16:49:41.145082-07:00</beginTime>
        <duration>1000</duration>
        <code>TRSP</code>
        <label></label>
        <description></description>
        <sourceDevice>Multi-Port ECI</sourceDevice>
        <keys>
            <key>
                <keyCode>cel#</keyCode>
                <description></description>
                <data dataType="short">2</data>
            </key>
            <key>
                <keyCode>obs#</keyCode>
                <description></description>
                <data dataType="short">3</data>
            </key>
            <key>
                <keyCode>rsp#</keyCode>
                <description></description>
                <data dataType="short">2</data>
            </key>
            <key>
                <keyCode>eval</keyCode>
                <description></description>
                <data dataType="short">0</data>
            </key>
            <key>
                <keyCode>rtim</keyCode>
                <description></description>
                <data dataType="long">1790</data>
            </key>
            <key>
                <keyCode>trl#</keyCode>
                <description></description>
                <data dataType="short">3</data>
            </key>
            <key>
                <keyCode>SCod</keyCode>
                <description></description>
                <data dataType="TEXT">Formation_3</data>
            </key>
...
```