### PR TITLE
A few modifications to categories.xml handling

### DIFF
--- a/mffpy/tests/test_reader.py
+++ b/mffpy/tests/test_reader.py
@@ -142,7 +142,8 @@ def test_get_physical_samples_multiple_bin_files(signals_3, mffpath_3):
 
 def test_get_mff_content(mffpath_2, json_example_2):
     mff = Reader(mffpath_2)
-    assert mff.get_mff_content() == json_example_2
+    mff_content = mff.get_mff_content()
+    assert mff_content == json_example_2
 
 
 def test_startdatetime(mffpath, mfzpath):

--- a/mffpy/tests/test_xml_files.py
+++ b/mffpy/tests/test_xml_files.py
@@ -371,7 +371,7 @@ def test_Categories(categories):
                 218, 219, 220, 221, 226, 234, 238, 239, 241, 247, 248, 250,
                 251, 253
             ]}],
-        'keys': None, 'faults': ['eyeb', 'eyem', 'badc']
+        'faults': ['eyeb', 'eyem', 'badc']
     }
     assert categories['ULRN'][0] == expected_ULRN0
     expected_LRND0 = {
@@ -383,8 +383,6 @@ def test_Categories(categories):
         'channelStatus': [{'signalBin': 1,
                            'exclusion': 'badChannels',
                            'channels': []}],
-        'keys': None,
-        'faults': []
     }
     assert categories['LRND'][0] == expected_LRND0
 
@@ -404,6 +402,7 @@ def test_Categories_to_xml():
         'first category': [
             {
                 'status': 'bad',
+                'name': 'Average',
                 'faults': ['eyeb'],
                 'beginTime': 0,
                 'endTime': 1200000,

--- a/mffpy/tests/test_xml_files.py
+++ b/mffpy/tests/test_xml_files.py
@@ -409,11 +409,13 @@ def test_Categories_to_xml():
                 'endTime': 1200000,
                 'evtBegin': 205135,
                 'evtEnd': 310153,
-                'channelStatus': {
-                    'signalBin': 1,
-                    'exclusion': 'badChannels',
-                    'channels': [1, 12, 25, 55]
-                },
+                'channelStatus': [
+                    {
+                        'signalBin': 1,
+                        'exclusion': 'badChannels',
+                        'channels': [1, 12, 25, 55]
+                    }
+                ],
                 'keys': {
                     '#seg': {
                         'type': 'long',
@@ -441,13 +443,8 @@ def test_Categories_to_xml():
     for name, category in categories.items():
         expected_category = expected_categories[name]
         for segment, expected in zip(category, expected_category):
-            assert segment['channelStatus'][0] == expected['channelStatus']
-            assert segment['keys'] == expected['keys']
-            assert segment['faults'] == expected['faults']
-            assert segment['beginTime'] == expected['beginTime']
-            assert segment['endTime'] == expected['endTime']
-            assert segment['evtBegin'] == expected['evtBegin']
-            assert segment['evtEnd'] == expected['evtEnd']
+            for key in segment.keys():
+                assert segment[key] == expected[key]
 
 
 def test_dipoleSet(dipoleSet):

--- a/mffpy/xml_files.py
+++ b/mffpy/xml_files.py
@@ -983,14 +983,16 @@ class Categories(XML):
                 }
 
             if 'channelStatus' in segment:
-                status = segment['channelStatus']
-                attributes = {
-                    'signalBin': str(int(status['signalBin'])),
-                    'exclusion': status['exclusion']
-                }
-                channels = ' '.join(map(str, status['channels']))
-                channels = {ATTR: attributes, TEXT: channels}
-                text['channelStatus'] = {TEXT: {'channels': channels}}
+                channels_list = []
+                for status in segment['channelStatus']:
+                    attributes = {
+                        'signalBin': str(int(status['signalBin'])),
+                        'exclusion': status['exclusion']
+                    }
+                    channels = ' '.join(map(str, status['channels']))
+                    channels = {ATTR: attributes, TEXT: channels}
+                    channels_list.append(channels)
+                text['channelStatus'] = {TEXT: {'channels': channels_list}}
 
             if 'keys' in segment:
                 # convert xml element 'data'


### PR DESCRIPTION
These are the changes that I would propose. The first commit is critical, since we sometimes have multiple entries in the 'channelStatus' field. The second commit is more a matter of preference. I reasoned since we have some elements of a segment that are optional, we only read these in if they are actually present and not completely empty. This allows us to fit the `Categories.categories` dict directly into `Categories.content`.