### PR TITLE
FIX: make version match release

### DIFF
--- a/mffpy/__init__.py
+++ b/mffpy/__init__.py
@@ -16,4 +16,4 @@ from .xml_files import XML  # noqa: F401
 from .reader import Reader  # noqa: F401
 from .writer import Writer  # noqa: F401
 
-__version__ = "0.5.0"
+__version__ = "0.5.5"

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 import pip
 import setuptools
+from mffpy import __version__
+
 
 def v1_ge_v2(module, version):
     """return `module.__version__ >= version`"""
@@ -45,7 +47,7 @@ else:
 
 setuptools.setup(
     name='mffpy',
-    version='0.5.5',
+    version=__version__,
     packages=setuptools.find_packages(),
     scripts=['./bin/mff2json.py', './bin/mff2mfz.py'],
     author='Justus Schwabedal, Wayne Manselle',


### PR DESCRIPTION
We have been forgetting to update `__version__` specified in `mffpy/__init__.py`. [This article](https://www.python.org/dev/peps/pep-0396/) recommends only having one place where the version needs to get updated with each release, so I followed their advice in having `setup.py` get the version number from `mffpy/__init__.py`.

I wasn't quite sure which branch to merge this into, so I played it safe and went with the `develop` branch. We will need this change to be reflected in the `v0.5.5` release if possible.