### PR TITLE
Release v0.5.6

### DIFF
--- a/mffpy/__init__.py
+++ b/mffpy/__init__.py
@@ -16,4 +16,4 @@ from .xml_files import XML  # noqa: F401
 from .reader import Reader  # noqa: F401
 from .writer import Writer  # noqa: F401
 
-__version__ = "0.5.5"
+__version__ = "0.5.6"


### PR DESCRIPTION
Just one bug fix in this release so that `mffpy.__version__` returns the right value.