### PR TITLE
Incorporate cached property

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,53 +31,56 @@ $ pre-commit install
 ### Test Coverage
 
 ```
-===================================================================== test session starts =====================================================================
-platform linux -- Python 3.6.7, pytest-6.1.1, py-1.9.0, pluggy-0.13.1
-rootdir: /home/jus/code/belco/mffpy
-plugins: cov-2.10.1
-collected 100 items
+====================================================================================== test session starts =======================================================================================
+platform darwin -- Python 3.6.10, pytest-5.2.0, py-1.8.1, pluggy-0.13.1
+rootdir: /Users/admin/Repositories/mffpy-public
+plugins: cov-2.6.1
+collected 102 items                                                                                                                                                                              
 
-mffpy/tests/test_devices.py ...........                                                                                                                 [ 11%]
-mffpy/tests/test_dict2xml.py .                                                                                                                          [ 12%]
-mffpy/tests/test_header_block.py ..                                                                                                                     [ 14%]
-mffpy/tests/test_mffdir.py ....                                                                                                                         [ 18%]
-mffpy/tests/test_raw_bin_files.py .............                                                                                                         [ 31%]
-mffpy/tests/test_reader.py ....................                                                                                                         [ 51%]
-mffpy/tests/test_writer.py ......                                                                                                                       [ 57%]
-mffpy/tests/test_xml_files.py ......................................                                                                                    [ 95%]
-mffpy/tests/test_zipfile.py .....                                                                                                                       [100%]
+mffpy/tests/test_cached_property.py ..                                                                                                                                                     [  1%]
+mffpy/tests/test_devices.py ...........                                                                                                                                                    [ 12%]
+mffpy/tests/test_dict2xml.py .                                                                                                                                                             [ 13%]
+mffpy/tests/test_header_block.py ..                                                                                                                                                        [ 15%]
+mffpy/tests/test_mffdir.py ....                                                                                                                                                            [ 19%]
+mffpy/tests/test_raw_bin_files.py .............                                                                                                                                            [ 32%]
+mffpy/tests/test_reader.py ....................                                                                                                                                            [ 51%]
+mffpy/tests/test_writer.py ......                                                                                                                                                          [ 57%]
+mffpy/tests/test_xml_files.py ......................................                                                                                                                       [ 95%]
+mffpy/tests/test_zipfile.py .....                                                                                                                                                          [100%]
 
------------ coverage: platform linux, python 3.6.7-final-0 -----------
-Name                                Stmts   Miss  Cover
--------------------------------------------------------
-mffpy/__init__.py                       4      0   100%
-mffpy/bin_files.py                     40      2    95%
-mffpy/bin_writer.py                    60      7    88%
-mffpy/devices.py                       10      0   100%
-mffpy/dict2xml.py                      31      3    90%
-mffpy/epoch.py                         24      5    79%
-mffpy/header_block.py                  50      1    98%
-mffpy/mffdir.py                        92      7    92%
-mffpy/raw_bin_files.py                 95      0   100%
-mffpy/reader.py                       103      2    98%
-mffpy/tests/__init__.py                 0      0   100%
-mffpy/tests/test_devices.py            12      0   100%
-mffpy/tests/test_dict2xml.py           15      0   100%
-mffpy/tests/test_header_block.py       37      0   100%
-mffpy/tests/test_mffdir.py             30      0   100%
-mffpy/tests/test_raw_bin_files.py      33      0   100%
-mffpy/tests/test_reader.py             82      0   100%
-mffpy/tests/test_writer.py            110      6    95%
-mffpy/tests/test_xml_files.py         167      1    99%
-mffpy/tests/test_zipfile.py            34      0   100%
-mffpy/writer.py                        60      2    97%
-mffpy/xml_files.py                    468     14    97%
-mffpy/zipfile.py                       47      0   100%
--------------------------------------------------------
-TOTAL                                1604     50    97%
+---------- coverage: platform darwin, python 3.6.10-final-0 ----------
+Name                                  Stmts   Miss  Cover
+---------------------------------------------------------
+mffpy/__init__.py                         4      0   100%
+mffpy/bin_files.py                       40      2    95%
+mffpy/bin_writer.py                      60      7    88%
+mffpy/cached_property.py                 25      1    96%
+mffpy/devices.py                         10      0   100%
+mffpy/dict2xml.py                        31      3    90%
+mffpy/epoch.py                           24      5    79%
+mffpy/header_block.py                    50      1    98%
+mffpy/mffdir.py                          92      7    92%
+mffpy/raw_bin_files.py                   95      0   100%
+mffpy/reader.py                         103      2    98%
+mffpy/tests/__init__.py                   0      0   100%
+mffpy/tests/test_cached_property.py      33      0   100%
+mffpy/tests/test_devices.py              12      0   100%
+mffpy/tests/test_dict2xml.py             15      0   100%
+mffpy/tests/test_header_block.py         37      0   100%
+mffpy/tests/test_mffdir.py               30      0   100%
+mffpy/tests/test_raw_bin_files.py        33      0   100%
+mffpy/tests/test_reader.py               82      0   100%
+mffpy/tests/test_writer.py              110      6    95%
+mffpy/tests/test_xml_files.py           167      1    99%
+mffpy/tests/test_zipfile.py              34      0   100%
+mffpy/writer.py                          60      2    97%
+mffpy/xml_files.py                      468     14    97%
+mffpy/zipfile.py                         47      0   100%
+---------------------------------------------------------
+TOTAL                                  1662     51    97%
 
 
-===================================================================== 100 passed in 3.07s =====================================================================
+====================================================================================== 102 passed in 4.89s =======================================================================================
 ```
 
 ## View the Docs

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ information.
 ```bash
 $ conda create -n mffpy python=3.6 pip
 $ conda activate mffpy
+$ pip install -r requirements.txt
 $ pip install -r requirements-dev.txt
 $ python setup.py install
 $ # and to run the test
@@ -32,9 +33,9 @@ $ pre-commit install
 
 ```
 ====================================================================================== test session starts =======================================================================================
-platform darwin -- Python 3.6.10, pytest-5.2.0, py-1.8.1, pluggy-0.13.1
+platform darwin -- Python 3.6.7, pytest-6.1.2, py-1.9.0, pluggy-0.13.1
 rootdir: /Users/admin/Repositories/mffpy-public
-plugins: cov-2.6.1
+plugins: cov-2.10.1
 collected 102 items                                                                                                                                                                              
 
 mffpy/tests/test_cached_property.py ..                                                                                                                                                     [  1%]
@@ -48,7 +49,7 @@ mffpy/tests/test_writer.py ......                                               
 mffpy/tests/test_xml_files.py ......................................                                                                                                                       [ 95%]
 mffpy/tests/test_zipfile.py .....                                                                                                                                                          [100%]
 
----------- coverage: platform darwin, python 3.6.10-final-0 ----------
+---------- coverage: platform darwin, python 3.6.7-final-0 -----------
 Name                                  Stmts   Miss  Cover
 ---------------------------------------------------------
 mffpy/__init__.py                         4      0   100%
@@ -80,7 +81,7 @@ mffpy/zipfile.py                         47      0   100%
 TOTAL                                  1662     51    97%
 
 
-====================================================================================== 102 passed in 4.89s =======================================================================================
+====================================================================================== 102 passed in 5.25s =======================================================================================
 ```
 
 ## View the Docs

--- a/mffpy/__init__.py
+++ b/mffpy/__init__.py
@@ -16,4 +16,4 @@ from .xml_files import XML  # noqa: F401
 from .reader import Reader  # noqa: F401
 from .writer import Writer  # noqa: F401
 
-__version__ = "0.5.6"
+__version__ = "0.5.7"

--- a/mffpy/cached_property.py
+++ b/mffpy/cached_property.py
@@ -1,0 +1,50 @@
+"""
+Copyright 2019 Brain Electrophysiology Laboratory Company LLC
+
+Licensed under the ApacheLicense, Version 2.0(the "License");
+you may not use this module except in compliance with the License.
+You may obtain a copy of the License at:
+
+http: // www.apache.org / licenses / LICENSE - 2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ANY KIND, either express or implied.
+"""
+import types
+
+
+def get_cached_property_name(obj):
+    if isinstance(obj, types.FunctionType):
+        name = obj.__name__
+    elif isinstance(obj, str):
+        name = obj
+    else:
+        raise ValueError("Invalid argument '%s'" % obj)
+    return '_cached_'+name
+
+
+def cached_property(fn):
+    cached_name = get_cached_property_name(fn)
+
+    @property
+    def _cached_property(self):
+        try:
+            return getattr(self, cached_name)
+        except AttributeError:
+            ans = fn(self)
+            setattr(self, cached_name, ans)
+            return ans
+    _cached_property.__doc__ = fn.__doc__
+    return _cached_property
+
+
+def drop_cache(obj, prop_name, permissive=False):
+    cached_name = get_cached_property_name(prop_name)
+    if hasattr(obj, cached_name):
+        delattr(obj, cached_name)
+    else:
+        if not permissive:
+            raise ValueError(
+                "Property '%s' not cached in object '%s'" % (prop_name, obj))

--- a/mffpy/raw_bin_files.py
+++ b/mffpy/raw_bin_files.py
@@ -19,7 +19,7 @@ from collections import namedtuple
 
 import numpy as np
 
-from cached_property import cached_property
+from mffpy.cached_property import cached_property
 
 from .header_block import read_header_block
 

--- a/mffpy/raw_bin_files.py
+++ b/mffpy/raw_bin_files.py
@@ -19,7 +19,7 @@ from collections import namedtuple
 
 import numpy as np
 
-from mffpy.cached_property import cached_property
+from .cached_property import cached_property
 
 from .header_block import read_header_block
 

--- a/mffpy/reader.py
+++ b/mffpy/reader.py
@@ -17,7 +17,7 @@ from typing import Tuple, Dict, List
 
 import numpy as np
 
-from cached_property import cached_property
+from mffpy.cached_property import cached_property
 
 from . import xml_files
 from .xml_files import XML, Categories, Epochs

--- a/mffpy/reader.py
+++ b/mffpy/reader.py
@@ -17,7 +17,7 @@ from typing import Tuple, Dict, List
 
 import numpy as np
 
-from mffpy.cached_property import cached_property
+from .cached_property import cached_property
 
 from . import xml_files
 from .xml_files import XML, Categories, Epochs

--- a/mffpy/tests/test_cached_property.py
+++ b/mffpy/tests/test_cached_property.py
@@ -1,0 +1,64 @@
+"""
+Copyright 2019 Brain Electrophysiology Laboratory Company LLC
+
+Licensed under the ApacheLicense, Version 2.0(the "License");
+you may not use this module except in compliance with the License.
+You may obtain a copy of the License at:
+
+http: // www.apache.org / licenses / LICENSE - 2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ANY KIND, either express or implied.
+"""
+import pytest
+from mffpy.cached_property import cached_property, drop_cache
+import time
+
+sleep_time = 0.4
+
+
+@pytest.fixture
+def dummy():
+    class Dummy:
+        @cached_property
+        def takes_some_time(self):
+            """some documentation code"""
+            time.sleep(sleep_time)
+            return 'unexpected time span'
+    return Dummy()
+
+
+def test_cached_property(dummy):
+    """Test that property is cached"""
+    # Test that doc string is transferred by decorator
+    assert type(dummy).takes_some_time.__doc__ == """some documentation code"""
+    # first time takes 1 second
+    t0 = time.time()
+    err = dummy.takes_some_time
+    dt = time.time()-t0
+    assert dt == pytest.approx(sleep_time, 1e-1), err
+    # second time takes zero second, because result is cached
+    # here we also test that the output didn't change.
+    t0 = time.time()
+    assert err == dummy.takes_some_time, "Cache has wrong value"
+    dt = time.time()-t0
+    assert dt == pytest.approx(0.0, abs=1e-1), err
+
+
+def test_drop_cache(dummy):
+    """test that cache is removed"""
+    # test that `drop_cache` can fail if no cache exists
+    drop_cache(dummy, 'takes_some_time', permissive=True)
+    with pytest.raises(ValueError):
+        drop_cache(dummy, 'takes_some_time')
+    t0 = time.time()
+    err = dummy.takes_some_time
+    dt = time.time()-t0
+    assert dt == pytest.approx(sleep_time, 1e-1), err
+    drop_cache(dummy, 'takes_some_time')
+    t0 = time.time()
+    assert err == dummy.takes_some_time, "Function output changed"
+    dt = time.time()-t0
+    assert dt == pytest.approx(sleep_time, abs=1e-1), err

--- a/mffpy/tests/test_cached_property.py
+++ b/mffpy/tests/test_cached_property.py
@@ -13,8 +13,9 @@ distributed under the License is distributed on an
 ANY KIND, either express or implied.
 """
 import pytest
-from mffpy.cached_property import cached_property, drop_cache
 import time
+
+from ..cached_property import cached_property, drop_cache
 
 sleep_time = 0.4
 

--- a/mffpy/xml_files.py
+++ b/mffpy/xml_files.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from collections import defaultdict
 import numpy as np
 from typing import Tuple, Dict, List, Any, Union, IO
-from cached_property import cached_property
+from mffpy.cached_property import cached_property
 from .dict2xml import TEXT, ATTR
 from .epoch import Epoch
 import copy

--- a/mffpy/xml_files.py
+++ b/mffpy/xml_files.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from collections import defaultdict
 import numpy as np
 from typing import Tuple, Dict, List, Any, Union, IO
-from mffpy.cached_property import cached_property
+from .cached_property import cached_property
 from .dict2xml import TEXT, ATTR
 from .epoch import Epoch
 import copy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 pytz>=2019.2
 numpy>=1.15.1
-cached_property_bel>=1.0.1


### PR DESCRIPTION
Our `cached_property_bel` dependency was causing issues with another library with a `cached_property` dependency in `mne-python`. Our solution is to pull in the code from `cached_property_bel` and make it a part of the `mffpy` library.