### PR TITLE
FIX 56: Data Blocks Offset

### DIFF
--- a/mffpy/bin_writer.py
+++ b/mffpy/bin_writer.py
@@ -62,7 +62,8 @@ class BinWriter(object):
     def get_info_kwargs(self):
         return {'fileDataType': self.data_type}
 
-    def _add_block_to_epochs(self, num_samples, offset_us):
+    def _add_block_to_epochs(self, num_samples: int,
+                             offset_us: Union[int, None]):
         """append `num_samples` to last epoch or make new epoch"""
         duration_us = int(10**6 * num_samples / self.sampling_rate)
         if len(self.epochs) == 0:

--- a/mffpy/tests/test_writer.py
+++ b/mffpy/tests/test_writer.py
@@ -154,6 +154,20 @@ def test_writer_writes_multple_bins():
         Clean-up failed of '{dirname}'.  Were additional files written?""")
 
 
+def test_write_multiple_blocks():
+    """check that BinWriter correctly handles adding multiple blocks"""
+    B = BinWriter(sampling_rate=250)
+    data = np.random.randn(257, 10).astype(np.float32)
+    B.add_block(data)
+    B.add_block(data, offset_us=None)
+    assert len(B.epochs) == 1
+    B.add_block(data, offset_us=0)
+    assert len(B.epochs) == 2
+    with pytest.raises(ValueError) as exc_info:
+        B.add_block(data, offset_us=-1)
+    assert str(exc_info.value) == 'offset_us cannot be negative. Got: -1.'
+
+
 def test_writer_is_compatible_with_egi():
     """check that binary writers fail to write EGI-incompatible files"""
     filename = join('.cache', 'unimportant-filename.mff')


### PR DESCRIPTION
See Issue #56. I ended up going with `None` as the default value for `offset_us`. If `offset_us=None` the data block is appended to the last block with no break. If `offset_us` is an `int`, there is a break and the data block gets its own new epoch.