### PR TITLE
Include LICENSE in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include mffpy/resources/coordinates/*xml
 include mffpy/resources/sensorLayout/*xml
+include LICENSE


### PR DESCRIPTION
I am currently building a package of `mffpy` for [conda-forge](https://conda-forge.org), and their guides strongly suggest that the license file be packaged with the sdist. Would be great if you could include it.