### PR TITLE
Chg(HeaderBlock): refactor into data class

### DIFF
--- a/mffpy/bin_writer.py
+++ b/mffpy/bin_writer.py
@@ -128,7 +128,7 @@ class BinWriter(object):
                 sampling_rate=self.sampling_rate,
             )
         # Write header/data to stream, and add an epochs block
-        self.header.to_file(self.stream)
+        self.header.write(self.stream)
         self.append(data.tobytes())
         self._add_block_to_epochs(num_samples, offset_us=offset_us)
 

--- a/mffpy/bin_writer.py
+++ b/mffpy/bin_writer.py
@@ -20,11 +20,7 @@ from os.path import join
 import numpy as np
 
 from .epoch import Epoch
-from .header_block import (
-    HeaderBlock,
-    write_header_block,
-    compute_header_byte_size
-)
+from .header_block import HeaderBlock
 
 
 class BinWriter(object):
@@ -117,7 +113,7 @@ class BinWriter(object):
         if self.header is None:
             self.header = HeaderBlock(
                 block_size=4 * data.size,
-                header_size=compute_header_byte_size(num_channels),
+                header_size=HeaderBlock.compute_byte_size(num_channels),
                 num_samples=num_samples,
                 num_channels=num_channels,
                 sampling_rate=self.sampling_rate,
@@ -132,7 +128,7 @@ class BinWriter(object):
                 sampling_rate=self.sampling_rate,
             )
         # Write header/data to stream, and add an epochs block
-        write_header_block(self.stream, self.header)
+        self.header.to_file(self.stream)
         self.append(data.tobytes())
         self._add_block_to_epochs(num_samples, offset_us=offset_us)
 

--- a/mffpy/header_block.py
+++ b/mffpy/header_block.py
@@ -40,27 +40,13 @@ ANY KIND, either express or implied.
 """
 import struct
 from os import SEEK_CUR
-from typing import IO, Union
+from typing import IO, Union, Optional, Tuple
 from collections import namedtuple
 from io import FileIO
 
 import numpy as np
 
-
-__all__ = [
-    'HeaderBlock',
-    'read_header_block',
-    'write_header_block',
-    'compute_header_byte_size'
-]
-
-HeaderBlock = namedtuple('HeaderBlock', [
-    'header_size',
-    'block_size',
-    'num_channels',
-    'num_samples',
-    'sampling_rate'
-])
+FileLike = Union[IO[bytes], FileIO]
 
 
 # Magic padding from '/examples/example_1.mff/signal1.bin', so that we survive
@@ -75,86 +61,131 @@ PADDING = np.array([
     1, 1, 0, 0],
     dtype=np.uint8).tobytes()
 
-
-def encode_rate_depth(rate: int, depth: int):
-    """return joined rate and byte depth of samples
-
-    Sampling rate and sample depth are encoded in a single 4-byte integer.  The
-    first byte is the depth the last 3 bytes give the sampling rate.
-    """
-    assert depth < (1 << 8), f"depth must be smaller than 256 (got {depth})"
-    assert rate < (1 << 24), f"depth must be smaller than {1<<24} (got {rate})"
-    return (rate << 8) + depth
+_HeaderBlock = namedtuple('_HeaderBlock', [
+    'header_size',
+    'block_size',
+    'num_channels',
+    'num_samples',
+    'sampling_rate'
+])
 
 
-def decode_rate_depth(x: int):
-    """return rate and depth from encoded representation"""
-    rate = x >> 8
-    depth = x & 0xff
-    return rate, depth
+def read(fp: FileLike, format_str: str):
+    num_bytes = struct.calcsize(format_str)
+    byts = fp.read(num_bytes)
+    ans = struct.unpack(format_str, byts)
+    return ans if len(ans) > 1 else ans[0]
 
 
-def compute_header_byte_size(num_channels):
-    return 4 * (4 + 2 * num_channels) + len(PADDING)
+def skip(fp: FileLike, n: int):
+    fp.seek(n, SEEK_CUR)
 
 
-def read_header_block(filepointer: IO[bytes]):
-    """return HeaderBlock, read from fp"""
-
-    def read(format_str: str):
-        num_bytes = struct.calcsize(format_str)
-        byts = filepointer.read(num_bytes)
-        ans = struct.unpack(format_str, byts)
-        return ans if len(ans) > 1 else ans[0]
-
-    def skip(n: int):
-        filepointer.seek(n, SEEK_CUR)
-
-    # Each block starts with a 4-byte-long header flag which is
-    # * `0`: there is no header
-    # * `1`: it follows a header
-    if read('i') == 0:
-        return None
-    # Read general information
-    header_size, block_size, num_channels = read('3i')
-    # number of 4-byte samples per channel in the data block
-    num_samples = (block_size//num_channels) // 4
-    # Read channel-specific information
-    nc4 = 4 * num_channels
-    # Skip byte offsets
-    skip(nc4)
-    # Sample rate/depth: Read one skip, over the rest
-    # We also check that depth is always 4-byte floats (32 bit)
-    sampling_rate, depth = decode_rate_depth(read('i'))
-    skip(nc4-4)
-    assert depth == 32, f"""
-    Unable to read MFF with `depth != 32` [`depth={depth}`]"""
-    # Skip the mysterious signal offset 2 (typically 24 bytes)
-    padding_byte_size = header_size - 16 - 2 * nc4
-    skip(padding_byte_size)
-    return HeaderBlock(
-        block_size=block_size,
-        header_size=header_size,
-        num_samples=num_samples,
-        num_channels=num_channels,
-        sampling_rate=sampling_rate,
-    )
+def write(fp: FileLike, format_str: str, items: tuple):
+    pack = struct.pack(format_str, *items)
+    fp.write(pack)
 
 
-def write_header_block(fp: Union[IO[bytes], FileIO], hdr: HeaderBlock):
-    """write HeaderBlock `hdr` to file pointer `fp`"""
-    fp.write(struct.pack('4i',
-                         1, hdr.header_size, hdr.block_size, hdr.num_channels))
-    num_samples = (hdr.block_size//hdr.num_channels) // 4
-    # Write channel offset into the data block
-    arr = 4 * num_samples * np.arange(hdr.num_channels).astype(np.int32)
-    fp.write(arr.tobytes())
-    # write sampling-rate/depth word
-    sr_d = encode_rate_depth(hdr.sampling_rate, 32)
-    arr = sr_d * np.ones(hdr.num_channels, dtype=np.int32)
-    fp.write(arr.tobytes())
-    pad_byte_len = hdr.header_size - 4 * (4 + 2 * hdr.num_channels)
-    # Pad either with zeros or with the magic `PADDING`
-    padding = PADDING if pad_byte_len == len(PADDING) \
-        else np.zeros(pad_byte_len, dtype=np.uint8).tobytes()
-    fp.write(padding)
+class HeaderBlock(_HeaderBlock):
+
+    HEADER_PRESENT = 1
+
+    def __new__(cls,
+                block_size: int,
+                num_channels: int,
+                num_samples: int,
+                sampling_rate: int,
+                header_size: Optional[int] = None):
+        """create new HeaderBlock instance
+
+        Parameters
+        ----------
+        block_size : byte size of the block
+        num_channels : channel count in the block
+        num_samples : sample count per channel in the block
+        sampling_rate : sampling_rate per channel in the block
+        header_size : byte size of the header (computed if None)
+        """
+        header_size = header_size or cls.compute_byte_size(num_channels)
+        return super().__new__(cls, header_size, block_size, num_channels,
+                               num_samples, sampling_rate)
+
+    @classmethod
+    def from_file(cls, fp: FileLike):
+        """return HeaderBlock, read from fp"""
+
+        # Each block starts with a 4-byte-long header flag which is
+        # * `0`: there is no header
+        # * `1`: it follows a header
+        if read(fp, 'i') == 0:
+            return None
+        # Read general information
+        header_size, block_size, num_channels = read(fp, '3i')
+        # number of 4-byte samples per channel in the data block
+        num_samples = (block_size//num_channels) // 4
+        # Read channel-specific information
+        nc4 = 4 * num_channels
+        # Skip byte offsets
+        skip(fp, nc4)
+        # Sample rate/depth: Read one skip, over the rest
+        # We also check that depth is always 4-byte floats (32 bit)
+        sampling_rate, depth = cls.decode_rate_depth(read(fp, 'i'))
+        skip(fp, nc4 - 4)
+        assert depth == 32, f"""
+        Unable to read MFF with `depth != 32` [`depth={depth}`]"""
+        # Skip the mysterious signal offset 2 (typically 24 bytes)
+        padding_byte_size = header_size - 16 - 2 * nc4
+        skip(fp, padding_byte_size)
+        return cls(
+            block_size=block_size,
+            header_size=header_size,
+            num_samples=num_samples,
+            num_channels=num_channels,
+            sampling_rate=sampling_rate,
+        )
+
+    def to_file(self, fp: FileLike):
+        """write HeaderBlock to file pointer `fp`"""
+        write(fp, '4i', (
+            self.HEADER_PRESENT,
+            self.header_size,
+            self.block_size,
+            self.num_channels
+        ))
+        num_samples = (self.block_size//self.num_channels) // 4
+        # Write channel offset into the data block
+        arr = 4 * num_samples * np.arange(self.num_channels).astype(np.int32)
+        fp.write(arr.tobytes())
+        # write sampling-rate/depth word
+        sr_d = self.encode_rate_depth(self.sampling_rate, 32)
+        arr = sr_d * np.ones(self.num_channels, dtype=np.int32)
+        fp.write(arr.tobytes())
+        pad_byte_len = self.header_size - 4 * (4 + 2 * self.num_channels)
+        # Pad either with zeros or with the magic `PADDING`
+        padding = PADDING if pad_byte_len == len(PADDING) \
+            else np.zeros(pad_byte_len, dtype=np.uint8).tobytes()
+        fp.write(padding)
+
+    @staticmethod
+    def decode_rate_depth(x: int) -> Tuple[int, int]:
+        """return rate and depth from encoded representation"""
+        rate = x >> 8
+        depth = x & 0xff
+        return rate, depth
+
+    @staticmethod
+    def encode_rate_depth(rate: int, depth: int) -> int:
+        """return joined rate and byte depth of samples
+
+        Sampling rate and sample depth are encoded in a single 4-byte integer.
+        The first byte is the depth the last 3 bytes give the sampling rate.
+        """
+        assert depth < (
+            1 << 8), f"depth must be smaller than 256 (got {depth})"
+        assert rate < (
+            1 << 24), f"depth must be smaller than {1<<24} (got {rate})"
+        return (rate << 8) + depth
+
+    @staticmethod
+    def compute_byte_size(num_channels: int) -> int:
+        return 4 * (4 + 2 * num_channels) + len(PADDING)

--- a/mffpy/header_block.py
+++ b/mffpy/header_block.py
@@ -144,7 +144,7 @@ class HeaderBlock(_HeaderBlock):
             sampling_rate=sampling_rate,
         )
 
-    def to_file(self, fp: FileLike):
+    def write(self, fp: FileLike):
         """write HeaderBlock to file pointer `fp`"""
         write(fp, '4i', (
             self.HEADER_PRESENT,

--- a/mffpy/raw_bin_files.py
+++ b/mffpy/raw_bin_files.py
@@ -21,7 +21,7 @@ import numpy as np
 
 from .cached_property import cached_property
 
-from .header_block import read_header_block
+from .header_block import HeaderBlock
 
 
 DataBlock = namedtuple('DataBlock', 'byte_offset byte_size')
@@ -113,7 +113,7 @@ class RawBinFile:
         for block_idx in itertools.count():
             if self.tell() >= self.bytes_in_file:
                 break
-            hdr = read_header_block(self.filepointer) or hdr
+            hdr = HeaderBlock.from_file(self.filepointer) or hdr
             assert hdr is not None, "First block must be a header"
             sampling_rate.append(hdr.sampling_rate)
             num_channels.append(hdr.num_channels)

--- a/mffpy/tests/test_header_block.py
+++ b/mffpy/tests/test_header_block.py
@@ -51,8 +51,8 @@ def test_written_header(example_header_bytes, dummy_header):
     example_header, _ = example_header_bytes
     fp = BytesIO()
     # write the header two times
-    example_header.to_file(fp)
-    dummy_header.to_file(fp)
+    example_header.write(fp)
+    dummy_header.write(fp)
     # read into `HeaderBlock` objects and compare
     fp.seek(0)
     assert example_header == HeaderBlock.from_file(fp)
@@ -64,7 +64,7 @@ def test_written_header_bytes(example_header_bytes):
     print(header)
     print(len(byts))
     fp = BytesIO()
-    header.to_file(fp)
+    header.write(fp)
     fp.seek(0)
     output_byts = fp.read()
     assert len(output_byts) == len(byts)

--- a/mffpy/tests/test_header_block.py
+++ b/mffpy/tests/test_header_block.py
@@ -14,11 +14,7 @@ ANY KIND, either express or implied.
 """
 from os.path import join, dirname
 import pytest
-from ..header_block import (
-    HeaderBlock,
-    read_header_block,
-    write_header_block
-)
+from ..header_block import HeaderBlock
 
 from io import BytesIO
 
@@ -45,7 +41,7 @@ def example_header_bytes():
     example_bin_file = join(dirname(__file__), '..', '..',
                             'examples', 'example_1.mff', 'signal1.bin')
     with open(example_bin_file, 'rb') as fp:
-        header = read_header_block(fp)
+        header = HeaderBlock.from_file(fp)
         fp.seek(0)
         byts = fp.read(header.header_size)
     return header, byts
@@ -55,12 +51,12 @@ def test_written_header(example_header_bytes, dummy_header):
     example_header, _ = example_header_bytes
     fp = BytesIO()
     # write the header two times
-    write_header_block(fp, example_header)
-    write_header_block(fp, dummy_header)
+    example_header.to_file(fp)
+    dummy_header.to_file(fp)
     # read into `HeaderBlock` objects and compare
     fp.seek(0)
-    assert example_header == read_header_block(fp)
-    assert dummy_header == read_header_block(fp)
+    assert example_header == HeaderBlock.from_file(fp)
+    assert dummy_header == HeaderBlock.from_file(fp)
 
 
 def test_written_header_bytes(example_header_bytes):
@@ -68,7 +64,7 @@ def test_written_header_bytes(example_header_bytes):
     print(header)
     print(len(byts))
     fp = BytesIO()
-    write_header_block(fp, header)
+    header.to_file(fp)
     fp.seek(0)
     output_byts = fp.read()
     assert len(output_byts) == len(byts)


### PR DESCRIPTION
We need to re-visit the magic padding in "header_block.py".  According to Robert's code the situation is like so:
If it starts with a 24 and a 1 (as our default PADDING), it follows that there is an optional header.  This
header seems to modify the block properties like so:

- bytes 0 to 4 : byte count of the optional header
- bytes 4 to 8 : type of the optional header (we know type '1')
- bytes 8 to 16 : total number of blocks
- bytes 16 to 24 : total number of samples (per channel?)
- bytes 24 to 28 : total number of signals

I infer this information from the lines following https://github.com/BEL-CO/mffjs/blob/9a85f6770c580dc8e4d2ee900ac7d985e1cbcfa7/src/SignalFile.js#L271

I'm neither sure if this is correct, or why it is designed like this.  Let's discuss and try to get this right.  Thanks :)

In this PR, I'm refactoring the `HeaderBlock` dataclass into a real class so that we can modify it more easily later on.