### PR TITLE
MAINT: Use FileNotFound rather than ValueError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
+test.xml
+examples/example_1.mfz
 
 # Translations
 *.mo

--- a/makefile
+++ b/makefile
@@ -3,10 +3,7 @@ examples/example_1.mfz: examples/example_1.mff
 	# zip -Z store -r -j ./examples/example_1.mfz ./examples/example_1.mff
 	-python ./bin/mff2mfz.py ./examples/example_1.mff
 
-
-# some tests depend on the existence of a zipped version of
-# 'examples/example_1.mff/'
-test: examples/example_1.mfz
+test:
 	mypy --ignore-missing-imports mffpy
 	pytest --cov
 

--- a/makefile
+++ b/makefile
@@ -12,4 +12,3 @@ test: examples/example_1.mfz
 
 clean:
 	-rm examples/example_1.mfz
-	-rm -rf .cache

--- a/mffpy/mffdir.py
+++ b/mffpy/mffdir.py
@@ -130,8 +130,9 @@ class MFFDirectory(MFFDirBase):
             if basename in files:
                 return join(self._mffname, basename) + ext
         else:
-            raise ValueError(f"No file with basename {basename} \
-                    in directory {super().__str__()}.")
+            raise FileNotFoundError(
+                f"No file with basename {basename} "
+                f"in directory {super().__str__()}.")
 
     def __contains__(self, filename: str) -> bool:
         return exists(filename)

--- a/mffpy/reader.py
+++ b/mffpy/reader.py
@@ -121,7 +121,7 @@ class Reader:
         # Attempt to add category names to the `Epoch` objects in `epochs`
         try:
             categories = self.categories
-        except (ValueError, AssertionError):
+        except (FileNotFoundError, AssertionError):
             print('categories.xml not found or of wrong type. '
                   '`Epoch.name` will default to "epoch" for all epochs.')
             return epochs

--- a/mffpy/tests/conftest.py
+++ b/mffpy/tests/conftest.py
@@ -1,0 +1,32 @@
+"""
+Copyright 2019 Brain Electrophysiology Laboratory Company LLC
+
+Licensed under the ApacheLicense, Version 2.0(the "License");
+you may not use this module except in compliance with the License.
+You may obtain a copy of the License at:
+
+http: // www.apache.org / licenses / LICENSE - 2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ANY KIND, either express or implied.
+"""
+
+from glob import glob
+import os.path as op
+from zipfile import ZipFile, ZIP_STORED
+
+import pytest
+
+
+@pytest.fixture(scope='session', autouse=True)
+def ensure_mfz():
+    """Ensure that the mfz file exists."""
+    fname = op.join(
+        op.dirname(__file__), '..', '..', 'examples', 'example_1.mfz')
+    if not op.isfile(fname):
+        with ZipFile(fname, mode='w', compression=ZIP_STORED) as zf:
+            for content_filename in glob(op.join(fname[:-3] + 'mff', '*')):
+                arc_filename = op.basename(content_filename)
+                zf.write(content_filename, arcname=arc_filename)

--- a/mffpy/tests/test_dict2xml.py
+++ b/mffpy/tests/test_dict2xml.py
@@ -12,17 +12,19 @@ distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 ANY KIND, either express or implied.
 """
+from os.path import join
+
 from ..dict2xml import dict2xml, TEXT, ATTR
 
 
-def test_dict2xml():
+def test_dict2xml(tmpdir):
     rootname = 'myroot'
     content = {
         'a': {TEXT: '35', ATTR: {'hello': 'world'}},
         'b': [{TEXT: 'b' + str(i+1)} for i in range(2)]
     }
     elem = dict2xml(content, rootname=rootname)
-    elem.write('test.xml')
+    elem.write(join(str(tmpdir), 'test.xml'))
     root = elem.getroot()
     a = root.find('a')
     bs = root.findall('b')

--- a/mffpy/tests/test_writer.py
+++ b/mffpy/tests/test_writer.py
@@ -27,9 +27,6 @@ from ..reader import Reader
 from ..xml_files import XML
 
 
-CACHE_DIR = '.cache'
-
-
 def test_writer_receives_bad_init_data():
     """Test bin writer fails when initialized with non-int sampling rate"""
     BinWriter(100)
@@ -38,20 +35,17 @@ def test_writer_receives_bad_init_data():
     assert str(exc_info.value) == "Sampling rate not int. Received 100.0"
 
 
-def test_writer_doesnt_overwrite():
+def test_writer_doesnt_overwrite(tmpdir):
     """test that `mffpy.Writer` doesn't overwrite existing files"""
-    dirname = join(CACHE_DIR, 'testdir.mff')
+    dirname = join(str(tmpdir), 'testdir.mff')
     makedirs(dirname, exist_ok=True)
-    with pytest.raises(AssertionError) as exc_info:
+    with pytest.raises(AssertionError, match='File.*exists already'):
         Writer(dirname)
-    assert str(exc_info.value) == "File '.cache/testdir.mff' exists already"
-
-    rmdir(dirname)
 
 
-def test_writer_writes():
+def test_writer_writes(tmpdir):
     """Test `mffpy.Writer` can write binary and xml files"""
-    dirname = join(CACHE_DIR, 'testdir2.mff')
+    dirname = join(str(tmpdir), 'testdir2.mff')
     # create some data and add it to a binary writer
     device = 'HydroCel GSN 256 1.0'
     num_samples = 10
@@ -94,9 +88,9 @@ def test_writer_writes():
         Clean-up failed of '{dirname}'.  Were additional files written?""")
 
 
-def test_writer_writes_multple_bins():
+def test_writer_writes_multple_bins(tmpdir):
     """test that `mffpy.Writer` can write multiple binary files"""
-    dirname = join(CACHE_DIR, 'multiple_bins.mff')
+    dirname = join(str(tmpdir), 'multiple_bins.mff')
     device = 'HydroCel GSN 256 1.0'
     # create some data and add it to binary writers
     num_samples = 10
@@ -214,9 +208,9 @@ def test_writer_exports_JSON():
         raise AssertionError(f"""Clean-up failed of '{filename}'.""")
 
 
-def test_streaming_writer_receives_bad_init_data():
+def test_streaming_writer_receives_bad_init_data(tmpdir):
     """Test bin writer fails when initialized with non-int sampling rate"""
-    dirname = join(CACHE_DIR, 'testdir.mff')
+    dirname = join(str(tmpdir), 'testdir.mff')
     makedirs(dirname)
     StreamingBinWriter(100, mffdir=dirname)
     with pytest.raises(AssertionError) as exc_info:
@@ -225,8 +219,8 @@ def test_streaming_writer_receives_bad_init_data():
     rmtree(dirname)
 
 
-def test_streaming_writer_writes():
-    dirname = join(CACHE_DIR, 'testdir3.mff')
+def test_streaming_writer_writes(tmpdir):
+    dirname = join(str(tmpdir), 'testdir3.mff')
     # create some data and add it to a binary writer
     device = 'HydroCel GSN 256 1.0'
     num_samples = 10

--- a/mffpy/tests/test_writer.py
+++ b/mffpy/tests/test_writer.py
@@ -13,9 +13,8 @@ distributed under the License is distributed on an
 ANY KIND, either express or implied.
 """
 from datetime import datetime
-from os import makedirs, rmdir, remove
+from os import makedirs
 from os.path import join
-from shutil import rmtree
 
 import pytest
 import json
@@ -74,18 +73,6 @@ def test_writer_writes(tmpdir):
     layout = R.directory.filepointer('sensorLayout')
     layout = XML.from_file(layout)
     assert layout.name == device
-    # cleanup
-    try:
-        remove(join(dirname, 'info.xml'))
-        remove(join(dirname, 'info1.xml'))
-        remove(join(dirname, 'epochs.xml'))
-        remove(join(dirname, 'signal1.bin'))
-        remove(join(dirname, 'coordinates.xml'))
-        remove(join(dirname, 'sensorLayout.xml'))
-        rmdir(dirname)
-    except BaseException:
-        raise AssertionError(f"""
-        Clean-up failed of '{dirname}'.  Were additional files written?""")
 
 
 def test_writer_writes_multple_bins(tmpdir):
@@ -134,20 +121,6 @@ def test_writer_writes_multple_bins(tmpdir):
     layout = R.directory.filepointer('sensorLayout')
     layout = XML.from_file(layout)
     assert layout.name == device
-    # cleanup
-    try:
-        remove(join(dirname, 'info.xml'))
-        remove(join(dirname, 'info1.xml'))
-        remove(join(dirname, 'signal1.bin'))
-        remove(join(dirname, 'info2.xml'))
-        remove(join(dirname, 'signal2.bin'))
-        remove(join(dirname, 'epochs.xml'))
-        remove(join(dirname, 'coordinates.xml'))
-        remove(join(dirname, 'sensorLayout.xml'))
-        rmdir(dirname)
-    except BaseException:
-        raise AssertionError(f"""
-        Clean-up failed of '{dirname}'.  Were additional files written?""")
 
 
 def test_write_multiple_blocks():
@@ -166,7 +139,7 @@ def test_write_multiple_blocks():
 
 def test_writer_is_compatible_with_egi():
     """check that binary writers fail to write EGI-incompatible files"""
-    filename = join('.cache', 'unimportant-filename.mff')
+    filename = 'unimportant-filename.mff'
     bin_writer = BinWriter(sampling_rate=128, data_type='PNSData')
     writer = Writer(filename)
     message = "Writing type 'PNSData' to 'signal1.bin' may be " \
@@ -181,8 +154,8 @@ def test_writer_is_compatible_with_egi():
     assert str(exc_info.value) == message
 
 
-def test_writer_exports_JSON():
-    filename = 'test1.json'
+def test_writer_exports_JSON(tmpdir):
+    filename = join(str(tmpdir), 'test1.json')
     # Root tags corresponding to available XMLType sub-classes
     xml_root_tags = ['fileInfo', 'dataInfo', 'patient', 'sensorLayout',
                      'coordinates', 'epochs', 'eventTrack', 'categories',
@@ -201,11 +174,6 @@ def test_writer_exports_JSON():
     with open(filename) as file:
         data = json.load(file)
     assert data == content
-    # cleanup
-    try:
-        remove(filename)
-    except BaseException:
-        raise AssertionError(f"""Clean-up failed of '{filename}'.""")
 
 
 def test_streaming_writer_receives_bad_init_data(tmpdir):
@@ -216,7 +184,6 @@ def test_streaming_writer_receives_bad_init_data(tmpdir):
     with pytest.raises(AssertionError) as exc_info:
         StreamingBinWriter(100.0, mffdir=dirname)
     assert str(exc_info.value) == "Sampling rate not int. Received 100.0"
-    rmtree(dirname)
 
 
 def test_streaming_writer_writes(tmpdir):
@@ -251,9 +218,3 @@ def test_streaming_writer_writes(tmpdir):
     layout = reader.directory.filepointer('sensorLayout')
     layout = XML.from_file(layout)
     assert layout.name == device
-    # cleanup
-    try:
-        rmtree(dirname)
-    except BaseException:
-        raise AssertionError(f"""
-        Clean-up failed of '{dirname}'.  Were additional files written?""")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,5 @@ pytest>=5.2.0
 pytest-cov>=2.6.1
 pre-commit>=2.7.1
 flake8==3.8.4
+types-pytz>=0.1.0
+types-deprecated>=0.1.1


### PR DESCRIPTION
Opens a PR to address the comment in https://github.com/mne-tools/mne-python/pull/9406#discussion_r644197354, namely that trying to open a file that does not exist should raise FileNotFoundError rather than ValueError. In trying to test this, `pytest` failed for me, for two reasons:

1. The `mfz` file did not exist. Some sleuthing suggested that I needed to do `python ./bin/mff2mfz.py ./examples/example_1.mff`, but it seems cleaner just to do it automagically using pytest `conftest.py`, which is now implemented.
2. When I had some failures due to my changes, I'd get some failures *not* due to my changes because of poor test isolation in `test_writer.py`. Specfically, the use of `.cache` across a bunch of tests creates dependencies that can be problematic. Using the standard `tmpdir` pytest fixture is a clean, standard way to address this issue, so I implemented it.

I can revert these if you want, but in theory this should make it easier for your users (or CIs, if you want to implement them!) to do `pytest` and just have things work, and to iterate over tests more easily.