### PR TITLE
FIX: Expect deprecation warning

### DIFF
--- a/mffpy/tests/test_reader.py
+++ b/mffpy/tests/test_reader.py
@@ -235,7 +235,8 @@ def test_mff_flavor(mffpath_2, mffpath_3, mffpath_4):
 
 def test_flavor(mffpath, mffpath_2, mffpath_3, mffpath_4):
     """test `Reader.flavor` for all .mff examples"""
-    assert Reader(mffpath).flavor == 'continuous'
-    assert Reader(mffpath_2).flavor == 'segmented'
-    assert Reader(mffpath_3).flavor == 'continuous'
-    assert Reader(mffpath_4).flavor == 'averaged'
+    with pytest.deprecated_call():
+        assert Reader(mffpath).flavor == 'continuous'
+        assert Reader(mffpath_2).flavor == 'segmented'
+        assert Reader(mffpath_3).flavor == 'continuous'
+        assert Reader(mffpath_4).flavor == 'averaged'


### PR DESCRIPTION
This gets rid of the deprecation warnings for calling `Reader.flavor` when running the test suite.

@damian5710, on another note, it looks like when `pytest-cov==3.0.0` (`coverage>=5.0.0`) is installed, this warning is thrown while running the test suite.

```
Users/admin/anaconda3/envs/mffpy/lib/python3.6/site-packages/coverage/data.py:129: CoverageWarning: Couldn't use data file '/Users/admin/Repositories/mffpy-public/.coverage.Evans-MacBook-Pro.local.9238.109870': Looks like a coverage 4.x data file. Are you mixing versions of coverage?
  data._warn(str(exc))
```

I have looked into this, but can't figure out the root cause. Do you see this behavior on your end as well?