### PR TITLE
Chg(gha): python version to matrix of 3.6-11

### DIFF
--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -16,15 +16,18 @@ jobs:
     name: Lint and Test
     # Set the type of machine to run on
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: ["3.6.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
         # Check out the latest commit from the current branch
       - name: Checkout Current Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Setup Python 3.6.7
-        uses: actions/setup-python@v2
+      - name: Setup Python { { matrix.python-version } }
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.6.7'
+          python-version: ${{ matrix.python-version }}
 
       - name: Cache Dependencies
         uses: actions/cache@v2
@@ -33,11 +36,11 @@ jobs:
           key: v1-dependencies-${{ hashFiles('**/requirements.txt') }}
           restore-keys: v1-dependencies-
 
-      - name: Install Dependences
-        run: pip install -r requirements.txt -r requirements-dev.txt
+      - name: Install Package
+        run: pip install .
 
-      - name: Run Setup Script
-        run: python setup.py install
+      - name: Install Development Dependences
+        run: pip install -r requirements.txt -r requirements-dev.txt
 
       - name: Linting
         run: flake8

--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -14,17 +14,17 @@ jobs:
   test_mffpy:
     # Name the job
     name: Lint and Test
-    # Set the type of machine to run on
-    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ["3.6.7", "3.8", "3.9", "3.10", "3.11"]
+    # Set the type of machine to run on
+    runs-on: ubuntu-20.04
     steps:
         # Check out the latest commit from the current branch
       - name: Checkout Current Branch
         uses: actions/checkout@v4
 
-      - name: Setup Python { { matrix.python-version } }
+      - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -40,7 +40,7 @@ jobs:
         run: pip install .
 
       - name: Install Development Dependences
-        run: pip install -r requirements.txt -r requirements-dev.txt
+        run: pip install -r requirements-dev.txt
 
       - name: Linting
         run: flake8

--- a/mffpy/bin_files.py
+++ b/mffpy/bin_files.py
@@ -85,7 +85,8 @@ class BinFile(raw_bin_files.RawBinFile):
         return self._scale
 
     def get_physical_samples(self, t0: float = 0.0,
-                             dt: Optional[float] = None, block_slice: Optional[slice] = None,
+                             dt: Optional[float] = None,
+                             block_slice: Optional[slice] = None,
                              dtype=np.float32) -> Tuple[np.ndarray, float]:
         samples, start_time = self.read_raw_samples(
             t0, dt, block_slice=block_slice)

--- a/mffpy/bin_files.py
+++ b/mffpy/bin_files.py
@@ -12,7 +12,7 @@ distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 ANY KIND, either express or implied.
 """
-from typing import Tuple, Dict, IO
+from typing import Tuple, Dict, IO, Optional
 
 import numpy as np
 
@@ -85,7 +85,7 @@ class BinFile(raw_bin_files.RawBinFile):
         return self._scale
 
     def get_physical_samples(self, t0: float = 0.0,
-                             dt: float = None, block_slice: slice = None,
+                             dt: Optional[float] = None, block_slice: Optional[slice] = None,
                              dtype=np.float32) -> Tuple[np.ndarray, float]:
         samples, start_time = self.read_raw_samples(
             t0, dt, block_slice=block_slice)

--- a/mffpy/mffdir.py
+++ b/mffpy/mffdir.py
@@ -16,7 +16,7 @@ import re
 from os import listdir
 from os.path import join, exists, splitext, basename, isdir
 from collections import defaultdict, namedtuple
-from typing import Dict, List, Tuple, IO
+from typing import Dict, List, Tuple, IO, Optional
 
 from . import zipfile
 
@@ -67,7 +67,7 @@ class MFFDirBase:
         for fbase, ext in (splitext(it) for it in self.listdir()):
             self.files_by_type[ext].append(fbase)
 
-    def info(self, i: int = None) -> IO[bytes]:
+    def info(self, i: Optional[int] = None) -> IO[bytes]:
         """return file or data info
 
         If `i is None`, it returns `<self.filename>/file.xml` else

--- a/mffpy/raw_bin_files.py
+++ b/mffpy/raw_bin_files.py
@@ -14,7 +14,7 @@ ANY KIND, either express or implied.
 """
 import itertools
 from os import SEEK_SET, SEEK_CUR, SEEK_END
-from typing import Tuple, Dict, IO, Union
+from typing import Tuple, Dict, IO, Union, Optional
 from warnings import warn
 from collections import namedtuple
 
@@ -57,7 +57,7 @@ class RawBinFile:
         self.buffering: bool = False
 
     def read_raw_samples(self, t0: float = 0.0,
-                         dt: float = None, block_slice: slice = None
+                         dt: Optional[float] = None, block_slice: Optional[slice] = None
                          ) -> Tuple[np.ndarray, float]:
         """return `(channels, samples)`-array and `start_time` of data
 

--- a/mffpy/raw_bin_files.py
+++ b/mffpy/raw_bin_files.py
@@ -56,8 +56,8 @@ class RawBinFile:
         assert not self.filepointer.closed
         self.buffering: bool = False
 
-    def read_raw_samples(self, t0: float = 0.0,
-                         dt: Optional[float] = None, block_slice: Optional[slice] = None
+    def read_raw_samples(self, t0: float = 0.0, dt: Optional[float] = None,
+                         block_slice: Optional[slice] = None
                          ) -> Tuple[np.ndarray, float]:
         """return `(channels, samples)`-array and `start_time` of data
 

--- a/mffpy/reader.py
+++ b/mffpy/reader.py
@@ -263,7 +263,8 @@ class Reader:
         }
 
     def get_physical_samples_from_epoch(self, epoch: xml_files.Epoch,
-                                        t0: float = 0.0, dt: Optional[float] = None,
+                                        t0: float = 0.0,
+                                        dt: Optional[float] = None,
                                         channels: Optional[List[str]] = None
                                         ) -> Dict[str,
                                                   Tuple[np.ndarray, float]]:

--- a/mffpy/reader.py
+++ b/mffpy/reader.py
@@ -13,7 +13,7 @@ distributed under the License is distributed on an
 ANY KIND, either express or implied.
 """
 from datetime import datetime
-from typing import Tuple, Dict, List
+from typing import Tuple, Dict, List, Optional
 
 from deprecated import deprecated
 import numpy as np
@@ -246,9 +246,9 @@ class Reader:
         """set calibration of a channel type"""
         self._blobs[channel_type].calibration = cal
 
-    def get_physical_samples(self, t0: float = 0.0, dt: float = None,
-                             channels: List[str] = None,
-                             block_slice: slice = None
+    def get_physical_samples(self, t0: float = 0.0, dt: Optional[float] = None,
+                             channels: Optional[List[str]] = None,
+                             block_slice: Optional[slice] = None
                              ) -> Dict[str, Tuple[np.ndarray, float]]:
         """return signal data in the range `(t0, t0+dt)` in seconds from `channels`
 
@@ -263,8 +263,8 @@ class Reader:
         }
 
     def get_physical_samples_from_epoch(self, epoch: xml_files.Epoch,
-                                        t0: float = 0.0, dt: float = None,
-                                        channels: List[str] = None
+                                        t0: float = 0.0, dt: Optional[float] = None,
+                                        channels: Optional[List[str]] = None
                                         ) -> Dict[str,
                                                   Tuple[np.ndarray, float]]:
         """

--- a/mffpy/tests/test_devices.py
+++ b/mffpy/tests/test_devices.py
@@ -46,7 +46,7 @@ def test_devices(device):
     locs = np.array([
         np.array([props['x'], props['y'], props['z']])
         for i, (_, props) in enumerate(coords.sensors.items())
-    ], dtype=np.float)
+    ], dtype=np.float32)
     device = basename(splitext(device)[0]) if exists(device) else device
     expected = np.load(join(resources_dir, 'testing', device+'.npy'),
                        allow_pickle=True)

--- a/mffpy/version.py
+++ b/mffpy/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.9.0-develop"
+__version__ = "0.9.0"

--- a/mffpy/xml_files.py
+++ b/mffpy/xml_files.py
@@ -4,7 +4,7 @@ from lxml import etree as ET
 from datetime import datetime
 from collections import defaultdict
 import numpy as np
-from typing import Tuple, Dict, List, Any, Union, IO
+from typing import Tuple, Dict, List, Any, Union, IO, Optional
 from .cached_property import cached_property
 from .dict2xml import TEXT, ATTR
 from .epoch import Epoch
@@ -202,10 +202,10 @@ class FileInfo(XML):
     @classmethod
     def content(cls, recordTime: datetime,  # type: ignore
                 mffVersion: str = '3',
-                acquisitionVersion: str = None,
-                ampType: str = None,
-                ampSerialNumber: str = None,
-                ampFirmwareVersion: str = None) -> dict:
+                acquisitionVersion: Optional[str] = None,
+                ampType: Optional[str] = None,
+                ampSerialNumber: Optional[str] = None,
+                ampFirmwareVersion: Optional[str] = None) -> dict:
         """returns MFF file information
 
         Only Version '3' is supported.
@@ -337,9 +337,9 @@ class DataInfo(XML):
 
     @classmethod
     def content(cls, fileDataType: str,  # type: ignore
-                dataTypeProps: dict = None,
-                filters: List[dict] = None,
-                calibrations: List[dict] = None) -> dict:
+                dataTypeProps: Optional[dict] = None,
+                filters: Optional[List[dict]] = None,
+                calibrations: Optional[List[dict]] = None) -> dict:
         """returns info on the associated (data) .bin file
 
         **Parameters**


### PR DESCRIPTION
This PR fixes issue #126 .

We haven't updated the versions of numpy (and python for that matter) appropriately.  I reviewed the currently stable versions of python which is 3.8 through 11 and added these to the tests.  I then performed changes accordingly.  No code change should affect the functionality of mffpy since it's mostly adding type annotations.