### PR TITLE
docs: fix voltage unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,10 @@ for i, e in enumerate(fo.epochs):
 from mffpy import Reader
 fo = Reader("./examples/example_1.mff")
 fo.set_unit('EEG', 'uV')
-eeg_in_mV, t0_EEG = fo.get_physical_samples_from_epoch(fo.epochs[0], dt=0.1)['EEG']
+eeg_in_uV, t0_EEG = fo.get_physical_samples_from_epoch(fo.epochs[0], dt=0.1)['EEG']
 fo.set_unit('EEG', 'V')
 eeg_in_V, t0_EEG = fo.get_physical_samples_from_epoch(fo.epochs[0], dt=0.1)['EEG']
-print('data in mV:', eeg_in_mV[0])
+print('data in uV:', eeg_in_uV[0])
 print('data in V :', eeg_in_V[0])
 ```
 


### PR DESCRIPTION
The voltage unit used in *Example 2* appears to be incorrect.

In the code, the unit is set to microvolts (`uV`), while the variable name and printed label indicate millivolts (`mV`), leading to an inconsistency:

```python
from mffpy import Reader
fo = Reader("./examples/example_1.mff")
fo.set_unit('EEG', 'uV')
eeg_in_mV, t0_EEG = fo.get_physical_samples_from_epoch(fo.epochs[0], dt=0.1)['EEG']
fo.set_unit('EEG', 'V')
eeg_in_V, t0_EEG = fo.get_physical_samples_from_epoch(fo.epochs[0], dt=0.1)['EEG']
print('data in mV:', eeg_in_mV[0])
print('data in V :', eeg_in_V[0])
```

This PR resolves the inconsistency by aligning the unit, variable names, and output labels.

An alternative fix would be to explicitly use millivolts (`mV`) instead:

```python
from mffpy import Reader
fo = Reader("./examples/example_1.mff")
fo.set_unit('EEG', 'mV')
eeg_in_mV, t0_EEG = fo.get_physical_samples_from_epoch(fo.epochs[0], dt=0.1)['EEG']
fo.set_unit('EEG', 'V')
eeg_in_V, t0_EEG = fo.get_physical_samples_from_epoch(fo.epochs[0], dt=0.1)['EEG']
print('data in mV:', eeg_in_mV[0])
print('data in V :', eeg_in_V[0])
```

However, since microvolts (`uV`) are more commonly used in EEG applications than millivolts (`mV`), the former approach was chosen.

Another possible option would be to include all three units (`uV`, `mV`, and `V`) in the example for completeness.