### PR TITLE
fix: avoid KeyError when getting type converter

### DIFF
--- a/mffpy/tests/test_xml_files.py
+++ b/mffpy/tests/test_xml_files.py
@@ -69,6 +69,13 @@ def patient():
 
 
 @pytest.fixture
+def patient3():
+    ans = join(mffpath_3, 'subject.xml')
+    assert exists(ans), f"Not found: '{ans}'"
+    return XML.from_file(ans)
+
+
+@pytest.fixture
 def sensor_layout():
     ans = join(mff_path, 'sensorLayout.xml')
     assert exists(ans), f"Not found: '{ans}'"
@@ -267,13 +274,26 @@ def test_DataInfo_calibrations_GCAL(field, expected, data_info):
             field, val, expected)
 
 
-@pytest.mark.parametrize("field,expected", [
-    ('localIdentifier', 'SE6P1'),
+@pytest.mark.parametrize("patient_fixture,field,expected", [
+    ('patient', 'localIdentifier', 'SE6P1'),
+    ('patient3', 'Patient ID', 'example_3'),
+    ('patient3', 'Date of Birth', None),
+    ('patient3', 'Age', None),
+    ('patient3', 'Gender', None),
+    ('patient3', 'Session Number', '1'),
 ])
-def test_subject(field, expected, patient):
-    val = patient.fields[field]
+def test_subject(field, expected, patient_fixture, request):
+    patient_obj = request.getfixturevalue(patient_fixture)
+    val = patient_obj.fields[field]
     assert val == expected, "subject.fields[%s] = %s [should be %s]" % (
         field, val, expected)
+
+
+def test_subject_unknown_type_converter(patient3):
+    with pytest.warns(UserWarning, match="unknown type converter for data type 'date'"):
+        date_of_birth = patient3.fields['Date of Birth']
+
+    assert date_of_birth is None
 
 
 @pytest.mark.parametrize("prop,idx,expected", [

--- a/mffpy/tests/test_xml_files.py
+++ b/mffpy/tests/test_xml_files.py
@@ -290,7 +290,10 @@ def test_subject(field, expected, patient_fixture, request):
 
 
 def test_subject_unknown_type_converter(patient3):
-    with pytest.warns(UserWarning, match="unknown type converter for data type 'date'"):
+    with pytest.warns(
+        UserWarning,
+        match="unknown type converter for data type 'date'",
+    ):
         date_of_birth = patient3.fields['Date of Birth']
 
     assert date_of_birth is None

--- a/mffpy/xml_files.py
+++ b/mffpy/xml_files.py
@@ -436,7 +436,8 @@ class Patient(XML):
             Unknown field with tag {self.nsstrip(field.tag)}"""
             name = self.find('name', field).text
             data = self.find('data', field)
-            data = self._type_converter[data.get('dataType')](data.text)
+            convert = self._type_converter.get(data.get('dataType'), self._type_converter[None])
+            data = convert(data.text)
             ans[name] = data
         return ans
 

--- a/mffpy/xml_files.py
+++ b/mffpy/xml_files.py
@@ -430,9 +430,20 @@ class Patient(XML):
     _default_filename = 'subject.xml'
 
     _type_converter = {
-        'string': str,
+        'choice': lambda x: x,
+        'string': lambda x: x,
         None: lambda x: x
     }
+
+    def _parse_field_data(self, data):
+        data_type = data.get('dataType')
+        if data_type in self._type_converter:
+            convert = self._type_converter[data_type]
+        else:
+            warnings.warn(f"unknown type converter for data type '{data_type}'.")
+            convert = self._type_converter[None]
+
+        return convert(data.text)
 
     @cached_property
     def fields(self):
@@ -442,8 +453,7 @@ class Patient(XML):
             Unknown field with tag {self.nsstrip(field.tag)}"""
             name = self.find('name', field).text
             data = self.find('data', field)
-            data = self._type_converter[data.get('dataType')](data.text)
-            ans[name] = data
+            ans[name] = self._parse_field_data(data)
         return ans
 
     @classmethod

--- a/mffpy/xml_files.py
+++ b/mffpy/xml_files.py
@@ -440,7 +440,9 @@ class Patient(XML):
         if data_type in self._type_converter:
             convert = self._type_converter[data_type]
         else:
-            warnings.warn(f"unknown type converter for data type '{data_type}'.")
+            warnings.warn(
+                f"unknown type converter for data type '{data_type}'."
+            )
             convert = self._type_converter[None]
 
         return convert(data.text)


### PR DESCRIPTION
When I attempted to read the patient metadata using the following code, an exception was raised:

```python
from pprint import pprint

import mffpy

reader = mffpy.Reader(r"./examples/example_2.mff") 
with reader.directory.filepointer("subject") as fp:
    subject_xml = mffpy.XML.from_file(fp)
    fields = subject_xml.get_content()
    pprint(fields)
```

This results in the following traceback:

```
Traceback (most recent call last):
  File "d:\mffpy\mffpy\cached_property.py", line 34, in _cached_property
    return getattr(self, cached_name)
AttributeError: 'Patient' object has no attribute '_cached_fields'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "d:\mffpy\test.py", line 6, in <module>
    fields = subject_xml.get_content()
  File "d:\mffpy\mffpy\xml_files.py", line 462, in get_content
    'fields': self.fields
              ^^^^^^^^^^^
Traceback (most recent call last):
  File "d:\mffpy\test.py", line 6, in <module>
    fields = subject_xml.get_content()
  File "d:\mffpy\mffpy\xml_files.py", line 462, in get_content
    'fields': self.fields
              ^^^^^^^^^^^
  File "d:\mffpy\test.py", line 6, in <module>
    fields = subject_xml.get_content()
  File "d:\mffpy\mffpy\xml_files.py", line 462, in get_content
    'fields': self.fields
              ^^^^^^^^^^^
    fields = subject_xml.get_content()
  File "d:\mffpy\mffpy\xml_files.py", line 462, in get_content
    'fields': self.fields
              ^^^^^^^^^^^
  File "d:\mffpy\mffpy\xml_files.py", line 462, in get_content
    'fields': self.fields
              ^^^^^^^^^^^
    'fields': self.fields
              ^^^^^^^^^^^
  File "d:\mffpy\mffpy\cached_property.py", line 36, in _cached_property
    ans = fn(self)
              ^^^^^^^^^^^
  File "d:\mffpy\mffpy\cached_property.py", line 36, in _cached_property
    ans = fn(self)
  File "d:\mffpy\mffpy\cached_property.py", line 36, in _cached_property
    ans = fn(self)
  File "d:\mffpy\mffpy\xml_files.py", line 439, in fields
    ans = fn(self)
  File "d:\mffpy\mffpy\xml_files.py", line 439, in fields
  File "d:\mffpy\mffpy\xml_files.py", line 439, in fields
    data = self._type_converter[data.get('dataType')](data.text)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'date'
```

The root cause of the issue can be found in the following section of the code:

https://github.com/BEL-Public/mffpy/blob/2509423ad2f08fee0836f267f57e5296fa4bba02/mffpy/xml_files.py#L420-L441

As shown there, `_type_converter` only defines converters for the keys `'string'` and `None`. However, patient metadata fields are not limited to these two data types. As a result, when encountering a field with a `dataType` such as `'date'`, the following line:

```python
data = self._type_converter[data.get('dataType')](data.text)
```

attempts to access a non-existent key in `_type_converter`, which leads to a `KeyError`.

In this PR, `dict.get(key, default)` is used to make the conversion more robust. When the specified `dataType` is not found in `_type_converter`, the logic now falls back to the default converter associated with `None` (i.e., `lambda x: x`), thereby avoiding the exception and preserving the original value.


