### PR TITLE
feat: add block_sample_counts public property to RawBinFile and Reader

### DIFF
--- a/mffpy/raw_bin_files.py
+++ b/mffpy/raw_bin_files.py
@@ -122,6 +122,16 @@ class RawBinFile:
             [0]+self.signal_blocks['num_samples'])
 
     @cached_property
+    def block_sample_counts(self) -> list:
+        """Number of samples in each signal block, in acquisition order.
+
+        Returns a list of ints, one per binary signal block.  Useful for
+        detecting per-block sample count mismatches across channel types
+        (e.g. the EGI PSG off-by-one bug).
+        """
+        return list(self.signal_blocks['num_samples'])
+
+    @cached_property
     def signal_blocks(self) -> Dict[str, Union[int, float, list]]:
         """return dictionary describing the signal file
 

--- a/mffpy/reader.py
+++ b/mffpy/reader.py
@@ -209,6 +209,29 @@ class Reader:
         }
 
     @cached_property
+    def block_sample_counts(self) -> Dict[str, list]:
+        """
+        ```python
+        Reader.block_sample_counts
+        ```
+        per-block sample counts by channel type
+
+        Return a dict mapping channel type (e.g. ``'EEG'``, ``'PNSData'``)
+        to a list of sample counts, one entry per binary signal block.  This
+        is the only reliable way to detect the EGI PSG off-by-one bug, where
+        the last PNS block contains one fewer sample than the corresponding
+        EEG block::
+
+            counts = reader.block_sample_counts
+            if counts.get('PNSData', [])[-1:] == [counts['EEG'][-1] - 1]:
+                # EGI PSG sample bug detected
+        """
+        return {
+            fn: bin_file.block_sample_counts
+            for fn, bin_file in self._blobs.items()
+        }
+
+    @cached_property
     def _blobs(self) -> Dict[str, bin_files.BinFile]:
         """return dictionary of `BinFile` data readers by signal type"""
         __blobs = {}

--- a/mffpy/tests/test_raw_bin_files.py
+++ b/mffpy/tests/test_raw_bin_files.py
@@ -57,6 +57,7 @@ def test_seek(rawbin):
     ('num_channels', 257),
     ('sampling_rate', 250.0),
     ('duration', 16.6),
+    ('block_sample_counts', [54, 4096]),
 ])
 def test_property(prop, expected, rawbin):
     assert getattr(rawbin, prop) == expected

--- a/mffpy/tests/test_reader.py
+++ b/mffpy/tests/test_reader.py
@@ -90,6 +90,7 @@ def json_example_2(examples_dir):
                                tzinfo=timezone(timedelta(-1, 57600)))),
     ('durations', {'EEG': 16.6}),
     ('sampling_rates', {'EEG': 250.0}),
+    ('block_sample_counts', {'EEG': [54, 4096]}),
 ])
 def test_property(prop, expected, reader):
     """test `Reader` reads `prop` of 'example_1.mff'"""
@@ -142,6 +143,24 @@ def test_get_no_physical_samples(reader):
 def test_get_physical_samples_full_range(reader):
     """test `Reader.get_physical_samples_from_epoch` does not fail"""
     reader.get_physical_samples_from_epoch(reader.epochs[0])
+
+
+def test_block_sample_counts_pns(mffpath_3):
+    """test `Reader.block_sample_counts` for a file with PNS data (example_3.mff)
+
+    Verifies that block_sample_counts exposes per-block counts for both EEG
+    and PNSData channel types, which is the mechanism used to detect the EGI
+    PSG off-by-one bug.
+    """
+    mff = Reader(mffpath_3)
+    counts = mff.block_sample_counts
+    assert 'EEG' in counts
+    assert 'PNSData' in counts
+    assert isinstance(counts['EEG'], list)
+    assert isinstance(counts['PNSData'], list)
+    assert len(counts['EEG']) == len(counts['PNSData'])
+    assert all(isinstance(n, int) for n in counts['EEG'])
+    assert all(isinstance(n, int) for n in counts['PNSData'])
 
 
 def test_get_physical_samples_multiple_bin_files(signals_3, mffpath_3):


### PR DESCRIPTION
RawBinFile and Reader had no public API for per-block sample counts. The only way to access them was via the private _blobs and signal_blocks internals.

Add `block_sample_counts` as a cached_property on both RawBinFile and Reader, following the same pattern as the existing sampling_rates, durations, and num_channels properties.

This is the only reliable way to detect the EGI PSG off-by-one bug, where the last PNS block contains one fewer sample than the corresponding EEG block. See `Reader.block_sample_counts` docstring for the detection pattern.