### PR TITLE
fix: Allow float-formatted numeric values in PNSSet sensor fields

### DIFF
--- a/mffpy/tests/test_xml_files.py
+++ b/mffpy/tests/test_xml_files.py
@@ -182,8 +182,10 @@ def test_PNSSet_sensors(pns_set):
     assert len(sensors) > 0
     first = next(iter(sensors.values()))
     assert isinstance(first['number'], int)
-    assert isinstance(first['samplingRate'], int)
-    assert isinstance(first['notch'], int)
+    assert isinstance(first['samplingRate'], float)
+    assert isinstance(first['highpass'], float)
+    assert isinstance(first['lowpass'], float)
+    assert isinstance(first['notch'], float)
 
 
 def test_FileInfo(file_info):

--- a/mffpy/tests/test_xml_files.py
+++ b/mffpy/tests/test_xml_files.py
@@ -83,6 +83,13 @@ def coordinates():
 
 
 @pytest.fixture
+def pns_set():
+    ans = join(examples_path, 'example_3.mff', 'pnsSet.xml')
+    assert exists(ans), f"Not found: '{ans}'"
+    return XML.from_file(ans)
+
+
+@pytest.fixture
 def epochs():
     ans = join(mff_path, 'epochs.xml')
     assert exists(ans), f"Not found: '{ans}'"
@@ -168,6 +175,15 @@ def test_from_file():
     expected_names = ['Category A_', 'Category B_', 'Category C_']
     category_names = sorted(output.categories.keys())
     assert category_names == expected_names
+
+
+def test_PNSSet_sensors(pns_set):
+    sensors = pns_set.sensors
+    assert len(sensors) > 0
+    first = next(iter(sensors.values()))
+    assert isinstance(first['number'], int)
+    assert isinstance(first['samplingRate'], int)
+    assert isinstance(first['notch'], int)
 
 
 def test_FileInfo(file_info):

--- a/mffpy/xml_files.py
+++ b/mffpy/xml_files.py
@@ -1380,34 +1380,26 @@ class PNSSet(XML):
         'positiveUp': str
     }
 
-    @staticmethod
-    def _parse_int_like(text: str) -> int:
-        """Parse integer-valued XML fields that may be written as floats."""
-        value = float(text)
-        if not value.is_integer():
-            raise ValueError(f"Expected integer-valued field, got {text!r}")
-        return int(value)
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._sensor_type_converter = {
             'name': str,
-            'number': self._parse_int_like,
+            'number': int,
             'unit': str,
-            'psgType': self._parse_int_like,
-            'mapping': self._parse_int_like,
-            'samplingRate': self._parse_int_like,
+            'psgType': int,
+            'mapping': int,
+            'samplingRate': float,
             'sensorType': str,
             'highpass': float,
             'lowpass': float,
-            'notch': self._parse_int_like,
-            'groupNumber': self._parse_int_like,
-            'gain': self._parse_int_like,
-            'conversion': self._parse_int_like,
+            'notch': float,
+            'groupNumber': int,
+            'gain': int,
+            'conversion': int,
             'defaultDisplayAmplitude': float,
             'highpassDisplay': float,
             'lowpassDisplay': float,
-            'notchDisplay': self._parse_int_like,
+            'notchDisplay': float,
             'color': lambda s: list(map(float, s.split(","))),
             'positiveUp': str,
         }

--- a/mffpy/xml_files.py
+++ b/mffpy/xml_files.py
@@ -1395,7 +1395,6 @@ class PNSSet(XML):
             'notch': float,
             'groupNumber': int,
             'gain': int,
-            'conversion': int,
             'defaultDisplayAmplitude': float,
             'highpassDisplay': float,
             'lowpassDisplay': float,

--- a/mffpy/xml_files.py
+++ b/mffpy/xml_files.py
@@ -1380,25 +1380,34 @@ class PNSSet(XML):
         'positiveUp': str
     }
 
+    @staticmethod
+    def _parse_int_like(text: str) -> int:
+        """Parse integer-valued XML fields that may be written as floats."""
+        value = float(text)
+        if not value.is_integer():
+            raise ValueError(f"Expected integer-valued field, got {text!r}")
+        return int(value)
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._sensor_type_converter = {
             'name': str,
-            'number': int,
+            'number': self._parse_int_like,
             'unit': str,
-            'psgType': int,
-            'mapping': int,
-            'samplingRate': int,
+            'psgType': self._parse_int_like,
+            'mapping': self._parse_int_like,
+            'samplingRate': self._parse_int_like,
             'sensorType': str,
             'highpass': float,
             'lowpass': float,
-            'notch': int,
-            'groupNumber': int,
-            'gain': int,
+            'notch': self._parse_int_like,
+            'groupNumber': self._parse_int_like,
+            'gain': self._parse_int_like,
+            'conversion': self._parse_int_like,
             'defaultDisplayAmplitude': float,
             'highpassDisplay': float,
             'lowpassDisplay': float,
-            'notchDisplay': int,
+            'notchDisplay': self._parse_int_like,
             'color': lambda s: list(map(float, s.split(","))),
             'positiveUp': str,
         }


### PR DESCRIPTION
Parse `PNSSet` numeric filter fields as floats.

Some real `pnsSet.xml` files store values like `notch` as `50.00`, which
caused parsing to fail when those fields were force treated as integers.

- updated `PNSSet` regression test
- targeted XML tests pass