### PR TITLE
feat: add optional defusedxml backend for XML parsing

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,7 @@
+def pytest_addoption(parser):
+    parser.addoption(
+        '--xml-backend',
+        default='lxml',
+        choices=['lxml', 'defusedxml'],
+        help='XML parsing backend to use (default: lxml)',
+    )

--- a/mffpy/__init__.py
+++ b/mffpy/__init__.py
@@ -13,6 +13,6 @@ distributed under the License is distributed on an
 ANY KIND, either express or implied.
 """
 from .version import __version__  # noqa: F401
-from .xml_files import XML  # noqa: F401
+from .xml_files import XML, set_backend  # noqa: F401
 from .reader import Reader  # noqa: F401
 from .writer import Writer  # noqa: F401

--- a/mffpy/header_block/header_block.py
+++ b/mffpy/header_block/header_block.py
@@ -142,7 +142,7 @@ class HeaderBlock(_HeaderBlock):
         assert depth < (
             1 << 8), f"depth must be smaller than 256 (got {depth})"
         assert rate < (
-            1 << 24), f"depth must be smaller than {1<<24} (got {rate})"
+            1 << 24), f"depth must be smaller than {1 << 24} (got {rate})"
         return (rate << 8) + depth
 
     @staticmethod

--- a/mffpy/reader.py
+++ b/mffpy/reader.py
@@ -273,7 +273,7 @@ class Reader:
                              channels: Optional[List[str]] = None,
                              block_slice: Optional[slice] = None
                              ) -> Dict[str, Tuple[np.ndarray, float]]:
-        """return signal data in the range `(t0, t0+dt)` in seconds from `channels`
+        """return signal data in range `(t0, t0+dt)` seconds from `channels`
 
         Use `get_physical_samples_from_epoch` instead."""
         if channels is None:

--- a/mffpy/tests/conftest.py
+++ b/mffpy/tests/conftest.py
@@ -20,6 +20,19 @@ from zipfile import ZipFile, ZIP_STORED
 
 import pytest
 
+import mffpy
+
+
+@pytest.fixture(scope='session', autouse=True)
+def xml_backend(request):
+    backend = request.config.getoption('--xml-backend')
+    mffpy.set_backend(backend)
+    if backend == 'defusedxml':
+        request.config.addinivalue_line(
+            'filterwarnings',
+            'ignore:recover=True is ignored:UserWarning',
+        )
+
 
 @pytest.fixture(scope='session', autouse=True)
 def ensure_mfz():

--- a/mffpy/tests/test_xml_files.py
+++ b/mffpy/tests/test_xml_files.py
@@ -13,6 +13,7 @@ distributed under the License is distributed on an
 ANY KIND, either express or implied.
 """
 import logging
+import xml.etree.ElementTree as stdlib_ET
 from io import BytesIO
 from lxml.etree import XMLSyntaxError
 from os.path import join, dirname, exists
@@ -22,7 +23,8 @@ import pytz
 import numpy as np
 import pytest
 
-from ..xml_files import XML
+import mffpy
+from ..xml_files import XML, set_backend
 from ..dict2xml import dict2xml
 
 logging.basicConfig(level=logging.DEBUG)
@@ -149,7 +151,7 @@ def test_parse_time_str(txt, expected):
     assert XML._parse_time_str(txt) == expected
 
 
-def test_from_file_raises():
+def test_from_file_raises(lxml_only):
     """assert that .from_file() raises if the XML file contains
     invalid Unicode characters and `recover` is `False`"""
     filepath = join(examples_path, 'example_5.mff', 'categories.xml')
@@ -158,7 +160,7 @@ def test_from_file_raises():
         XML.from_file(filepath, recover=False)
 
 
-def test_from_file():
+def test_from_file(lxml_only):
     """assert that .from_file() parses an XML file that contains
     invalid Unicode characters if `recover` is `True`"""
     filepath = join(examples_path, 'example_5.mff', 'categories.xml')
@@ -168,6 +170,78 @@ def test_from_file():
     expected_names = ['Category A_', 'Category B_', 'Category C_']
     category_names = sorted(output.categories.keys())
     assert category_names == expected_names
+
+
+@pytest.fixture
+def lxml_only(request):
+    """Skip the test if the active backend is not lxml."""
+    from .. import xml_files
+    if xml_files._xml_backend != 'lxml':
+        pytest.skip("test requires the lxml backend")
+
+
+@pytest.fixture(autouse=True)
+def reset_backend():
+    """Restore whatever backend was active before each test."""
+    from .. import xml_files
+    prior = xml_files._xml_backend
+    yield
+    set_backend(prior)
+
+
+def test_set_backend_invalid():
+    with pytest.raises(ValueError, match="Unknown backend"):
+        set_backend('notabackend')
+
+
+def test_set_backend_defusedxml_import_error(monkeypatch):
+    import builtins
+    real_import = builtins.__import__
+
+    def _block_defusedxml(name, *args, **kwargs):
+        if name == 'defusedxml':
+            raise ImportError("blocked")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, '__import__', _block_defusedxml)
+    with pytest.raises(ImportError, match="defusedxml"):
+        set_backend('defusedxml')
+
+
+def test_defusedxml_backend_parses(tmp_path):
+    """defusedxml backend parses a well-formed XML file correctly."""
+    filepath = join(examples_path, 'example_1.mff', 'epochs.xml')
+    assert exists(filepath), f"Not found: '{filepath}'"
+    pytest.importorskip('defusedxml')
+    set_backend('defusedxml')
+    result = XML.from_file(filepath, recover=False)
+    assert result is not None
+
+
+def test_defusedxml_backend_recover_warning():
+    """defusedxml backend emits UserWarning when recover=True."""
+    filepath = join(examples_path, 'example_1.mff', 'epochs.xml')
+    assert exists(filepath), f"Not found: '{filepath}'"
+    pytest.importorskip('defusedxml')
+    set_backend('defusedxml')
+    with pytest.warns(UserWarning, match="recover=True is ignored"):
+        XML.from_file(filepath, recover=True)
+
+
+def test_defusedxml_backend_parse_error_hint(tmp_path):
+    """defusedxml backend ParseError includes a hint to switch to lxml."""
+    pytest.importorskip('defusedxml')
+    broken = tmp_path / "broken.xml"
+    broken.write_bytes(b"<notclosed>")
+    set_backend('defusedxml')
+    with pytest.raises(stdlib_ET.ParseError, match="mffpy.set_backend"):
+        XML.from_file(str(broken), recover=False)
+
+
+def test_set_backend_via_mffpy_namespace():
+    """set_backend is accessible as mffpy.set_backend."""
+    assert hasattr(mffpy, 'set_backend')
+    mffpy.set_backend('lxml')
 
 
 def test_FileInfo(file_info):

--- a/mffpy/tests/test_xml_files.py
+++ b/mffpy/tests/test_xml_files.py
@@ -166,7 +166,7 @@ def test_from_file(lxml_only):
     filepath = join(examples_path, 'example_5.mff', 'categories.xml')
     assert exists(filepath), f"Not found: '{filepath}'"
     output = XML.from_file(filepath)
-    assert type(output) == type(XML)._tag_registry['categories']
+    assert isinstance(output, type(XML)._tag_registry['categories'])
     expected_names = ['Category A_', 'Category B_', 'Category C_']
     category_names = sorted(output.categories.keys())
     assert category_names == expected_names
@@ -473,7 +473,7 @@ def test_EventTrack_to_xml():
     xml_stream.seek(0)
     # read the .xml and test content
     output = XML.from_file(xml_stream)
-    assert type(output) == type(XML)._tag_registry['eventTrack']
+    assert isinstance(output, type(XML)._tag_registry['eventTrack'])
     assert output.name == name
     assert output.trackType == trackType
     assert len(output.events) == len(events)
@@ -577,7 +577,7 @@ def test_Categories_to_xml(channel_status):
     xml_stream.seek(0)
     # read the .xml and test content
     output = XML.from_file(xml_stream)
-    assert type(output) == type(XML)._tag_registry['categories']
+    assert isinstance(output, type(XML)._tag_registry['categories'])
     categories = output.categories
     for name, category in categories.items():
         expected_category = expected_categories[name]
@@ -691,7 +691,7 @@ def test_history_to_xml():
               xml_declaration=True, method='xml')
     xml_stream.seek(0)
     output = XML.from_file(xml_stream)
-    assert type(output) == type(XML)._tag_registry['historyEntries']
+    assert isinstance(output, type(XML)._tag_registry['historyEntries'])
     assert len(output) == len(entries)
     for entry, expected in zip(entries, output.entries):
         assert entry == expected

--- a/mffpy/xml_files.py
+++ b/mffpy/xml_files.py
@@ -42,6 +42,8 @@ def set_backend(backend: str) -> None:
                 "backend. Install it with: pip install defusedxml"
             )
     _xml_backend = backend
+
+
 """
 Copyright 2019 Brain Electrophysiology Laboratory Company LLC
 
@@ -1331,9 +1333,10 @@ class DipoleSet(XML):
 
         # check that all dipole attributes have same lengths and 3 components
         shp = (len(dipole_tags), 3)
-        assert all(v.shape == shp for v in d_arrays.values()), f"""
-        Parsing dipoles result in broken shape.  Found {[(k, v.shape) for k, v
-        in d_arrays.items()]}"""
+        shapes = [(k, v.shape) for k, v in d_arrays.items()]
+        assert all(v.shape == shp for v in d_arrays.values()), (
+            f"Parsing dipoles result in broken shape.  Found {shapes}"
+        )
         return d_arrays
 
     def get_content(self):

--- a/mffpy/xml_files.py
+++ b/mffpy/xml_files.py
@@ -1,5 +1,6 @@
 import logging
 import warnings
+import xml.etree.ElementTree as _stdlib_ET
 from lxml import etree as ET
 from datetime import datetime
 from collections import defaultdict
@@ -10,6 +11,37 @@ from .dict2xml import TEXT, ATTR
 from .epoch import Epoch
 import copy
 import re
+
+_VALID_BACKENDS = ('lxml', 'defusedxml')
+_xml_backend: str = 'lxml'
+
+
+def set_backend(backend: str) -> None:
+    """Select the XML parsing backend used by :meth:`XMLType.from_file`.
+
+    **Parameters**
+    *backend*: ``'lxml'`` (default) or ``'defusedxml'``
+        ``'lxml'`` enables the ``recover`` option for broken XML files.
+        ``'defusedxml'`` disables ``recover`` but guards against XML
+        security vulnerabilities (entity expansion, XXE, etc.).
+
+    Raises ``ValueError`` for unknown backend names and ``ImportError``
+    if ``'defusedxml'`` is requested but not installed.
+    """
+    global _xml_backend
+    if backend not in _VALID_BACKENDS:
+        raise ValueError(
+            f"Unknown backend {backend!r}. Choose one of {_VALID_BACKENDS}."
+        )
+    if backend == 'defusedxml':
+        try:
+            import defusedxml  # noqa: F401
+        except ImportError:
+            raise ImportError(
+                "The 'defusedxml' package is required to use the defusedxml "
+                "backend. Install it with: pip install defusedxml"
+            )
+    _xml_backend = backend
 """
 Copyright 2019 Brain Electrophysiology Laboratory Company LLC
 
@@ -76,9 +108,34 @@ class XMLType(type):
             indicates whether to try hard to parse through broken XML or not.
             Set to `True` by default because it's necessary if there are weird
             characters in the xml file, which can occasionally occur.
+            Ignored (with a warning) when the active backend is ``'defusedxml'``;
+            use :func:`mffpy.set_backend` to change the backend.
         """
+        if _xml_backend == 'defusedxml':
+            return typ._from_file_defusedxml(filepointer, recover)
         parser = ET.XMLParser(recover=recover)
         xml_root = ET.parse(filepointer, parser).getroot()
+        return typ._registry[xml_root.tag](xml_root)
+
+    @classmethod
+    def _from_file_defusedxml(typ, filepointer: FilePointer, recover: bool):
+        import defusedxml.ElementTree as DET
+        if recover:
+            warnings.warn(
+                "recover=True is ignored when using the defusedxml backend. "
+                "Switch to the lxml backend (mffpy.set_backend('lxml')) if "
+                "you need to parse broken XML.",
+                UserWarning,
+                stacklevel=3,
+            )
+        try:
+            xml_root = DET.parse(filepointer).getroot()
+        except _stdlib_ET.ParseError as exc:
+            raise _stdlib_ET.ParseError(
+                f"{exc}. XML parsing failed using the defusedxml backend. "
+                "If the file contains recoverable errors, switch to the lxml "
+                "backend: mffpy.set_backend('lxml')"
+            ) from exc
         return typ._registry[xml_root.tag](xml_root)
 
     @classmethod

--- a/mffpy/xml_files.py
+++ b/mffpy/xml_files.py
@@ -108,7 +108,7 @@ class XMLType(type):
             indicates whether to try hard to parse through broken XML or not.
             Set to `True` by default because it's necessary if there are weird
             characters in the xml file, which can occasionally occur.
-            Ignored (with a warning) when the active backend is ``'defusedxml'``;
+            Ignored (warning) when the active backend is ``'defusedxml'``;
             use :func:`mffpy.set_backend` to change the backend.
         """
         if _xml_backend == 'defusedxml':


### PR DESCRIPTION
# WIP - Work in progress

Adds `mffpy.set_backend()` to allow switching the XML parsing backend
from lxml (default) to defusedxml, which guards against XML security
vulnerabilities.

- Default remains `lxml` with `recover=True` behavior unchanged
- `mffpy.set_backend('defusedxml')` opts in to defusedxml parsing
- `set_backend('defusedxml')` raises `ImportError` with a clear message
  if defusedxml is not installed (`pip install defusedxml`)
- Calling `XML.from_file(..., recover=True)` with the defusedxml backend
  emits a `UserWarning` (recover is silently ignored, since defusedxml
  does not support it)
- If defusedxml raises a `ParseError`, the exception message includes a
  hint to switch back to lxml for broken-but-recoverable files
- `pytest --xml-backend=defusedxml` runs the full test suite under the
  defusedxml backend; lxml-specific tests (`recover=True` behavior) are
  skipped automatically