### PR TITLE
fix: do not run GitHub Actions on draft PRs

### DIFF
--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -6,7 +6,8 @@ on:
     branches:
       - master
       - develop
-  pull_request: # This will trigger on all pull requests.
+  pull_request: # This will trigger on all non-draft pull requests.
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   # Set the job key. The key is displayed as the job name

--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -8,6 +8,7 @@ on:
       - develop
   pull_request: # This will trigger on all non-draft pull requests.
     types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
 
 jobs:
   # Set the job key. The key is displayed as the job name


### PR DESCRIPTION
do not run GitHub Actions on draft PRs

`[opened, synchronize, reopened, ready_for_review]`

- opened — fires when a new PR is created (non-draft)
- synchronize — fires when new commits are pushed to an existing PR
- reopened — fires when a closed PR is reopened
- ready_for_review — fires when a draft PR is marked as ready for review