### PR TITLE
Fix: Updated docs build for pydoc-markdown v4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ venv.bak/
 
 # mkdocs documentation
 /site
+docs/html/
 
 # mypy
 .mypy_cache/

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ TOTAL                                          2100     44    98%
 All documentation and API guidance are generated from the python doc-strings
 and this README file using pydoc-markdown.  To view the docs:
 
-* install pydoc-markdown: `pip install pydoc-markdown`
-* build and run:  `pydocmd build; pydocmd serve`
+* install dependencies: `pip install pydoc-markdown mkdocs`
+* build and serve: `make docs-serve`
 * Navigate to the [docs](http://localhost:8000)
 
 ## Example Code

--- a/README.md
+++ b/README.md
@@ -122,10 +122,10 @@ for i, e in enumerate(fo.epochs):
 from mffpy import Reader
 fo = Reader("./examples/example_1.mff")
 fo.set_unit('EEG', 'uV')
-eeg_in_mV, t0_EEG = fo.get_physical_samples_from_epoch(fo.epochs[0], dt=0.1)['EEG']
+eeg_in_uV, t0_EEG = fo.get_physical_samples_from_epoch(fo.epochs[0], dt=0.1)['EEG']
 fo.set_unit('EEG', 'V')
 eeg_in_V, t0_EEG = fo.get_physical_samples_from_epoch(fo.epochs[0], dt=0.1)['EEG']
-print('data in mV:', eeg_in_mV[0])
+print('data in uV:', eeg_in_uV[0])
 print('data in V :', eeg_in_V[0])
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ information.
 ## Installation
 
 ```bash
-$ conda create -n mffpy python=3.6 pip
+$ conda create -n mffpy python=3.8 pip
 $ conda activate mffpy
 $ pip install -r requirements-dev.txt
 $ pip install .

--- a/makefile
+++ b/makefile
@@ -3,6 +3,14 @@ examples/example_1.mfz: examples/example_1.mff
 	# zip -Z store -r -j ./examples/example_1.mfz ./examples/example_1.mff
 	-python ./bin/mff2mfz.py ./examples/example_1.mff
 
+docs:
+	pydoc-markdown
+	cd build/docs && mkdocs build --site-dir ../../docs/html
+	@echo "Docs at docs/html/index.html"
+
+docs-serve:
+	pydoc-markdown -s -o
+
 test:
 	mypy --ignore-missing-imports mffpy
 	pytest --cov

--- a/mffpy/xml_files.py
+++ b/mffpy/xml_files.py
@@ -67,15 +67,50 @@ class XMLType(type):
 
     @classmethod
     def from_file(typ, filepointer: FilePointer, recover: bool = True):
-        """return new `XMLType` instance of the appropriate sub-class
+        """Parse an MFF XML file and return the appropriate typed object.
+
+        The returned type depends on the root tag of the XML file.  Common
+        return types are:
+
+        * `EventTrack` — for ``Events_*.xml`` files (stimulus/response events)
+        * `Categories` — for ``categories.xml`` (segmentation metadata)
+        * `FileInfo`   — for ``info.xml``
+        * `Epochs`     — for ``epochs.xml``
+
+        **Example — read events from an MFF**
+
+        ```python
+        import mffpy
+        from mffpy.xml_files import XML
+
+        # Open the MFF directory
+        folder = mffpy.Reader("my_recording.mff")
+
+        # Grab the first event track (often called "Events_ECI")
+        event_track = XML.from_file(folder.directory.filepointer("Events_ECI.xml"))
+
+        # .events is a list of dicts, one per event
+        for evt in event_track.events:
+            print(evt['code'], evt['beginTime'], evt.get('duration'))
+        ```
+
+        Each event dict may contain:
+
+        * ``beginTime`` — `datetime` of the event onset (absolute, timezone-aware)
+        * ``duration``  — duration in microseconds (`int`)
+        * ``relativeBeginTime`` — onset relative to recording start, in microseconds (`int`)
+        * ``code``      — event code string
+        * ``label``     — human-readable label
+        * ``description`` — longer description
+        * ``keys``      — dict of auxiliary key/value pairs (e.g. ``{'cel#': 1}``)
 
         **Parameters**
+
         *filepointer*: str or IO[bytes]
-            pointer to the xml file
+            Path to the xml file, or an open binary file-like object.
         *recover*: bool
-            indicates whether to try hard to parse through broken XML or not.
-            Set to `True` by default because it's necessary if there are weird
-            characters in the xml file, which can occasionally occur.
+            Whether to try hard to parse through broken XML.  Defaults to
+            ``True`` because some EGI files contain non-standard characters.
         """
         parser = ET.XMLParser(recover=recover)
         xml_root = ET.parse(filepointer, parser).getroot()

--- a/mffpy/xml_files.py
+++ b/mffpy/xml_files.py
@@ -87,7 +87,8 @@ class XMLType(type):
         folder = mffpy.Reader("my_recording.mff")
 
         # Grab the first event track (often called "Events_ECI")
-        event_track = XML.from_file(folder.directory.filepointer("Events_ECI.xml"))
+        fp = folder.directory.filepointer("Events_ECI.xml")
+        event_track = XML.from_file(fp)
 
         # .events is a list of dicts, one per event
         for evt in event_track.events:
@@ -96,13 +97,15 @@ class XMLType(type):
 
         Each event dict may contain:
 
-        * ``beginTime`` — `datetime` of the event onset (absolute, timezone-aware)
+        * ``beginTime`` — `datetime` onset (absolute, timezone-aware)
         * ``duration``  — duration in microseconds (`int`)
-        * ``relativeBeginTime`` — onset relative to recording start, in microseconds (`int`)
+        * ``relativeBeginTime`` — onset relative to recording start (`int`,
+          microseconds)
         * ``code``      — event code string
         * ``label``     — human-readable label
         * ``description`` — longer description
-        * ``keys``      — dict of auxiliary key/value pairs (e.g. ``{'cel#': 1}``)
+        * ``keys``      — dict of auxiliary key/value pairs
+          (e.g. ``{'cel#': 1}``)
 
         **Parameters**
 

--- a/pydoc-markdown.yml
+++ b/pydoc-markdown.yml
@@ -22,6 +22,11 @@ renderer:
           contents:
             - mffpy.epoch.Epoch
             - mffpy.epoch.Epoch.*
+        - title: XML
+          contents:
+            - mffpy.xml_files.XMLType.from_file
+            - mffpy.xml_files.EventTrack
+            - mffpy.xml_files.EventTrack.*
   mkdocs_config:
     site_name: mffpy
     theme:

--- a/pydoc-markdown.yml
+++ b/pydoc-markdown.yml
@@ -1,0 +1,28 @@
+loaders:
+  - type: python
+    search_path: [.]
+processors:
+  - type: filter
+  - type: smart
+  - type: crossref
+renderer:
+  type: mkdocs
+  output_directory: build/docs
+  pages:
+    - title: Overview
+      name: index
+      source: README.md
+    - title: API
+      children:
+        - title: Reader
+          contents:
+            - mffpy.reader.Reader
+            - mffpy.reader.Reader.*
+        - title: Epoch
+          contents:
+            - mffpy.epoch.Epoch
+            - mffpy.epoch.Epoch.*
+  mkdocs_config:
+    site_name: mffpy
+    theme:
+      name: readthedocs


### PR DESCRIPTION
The existing pydocmd.yml config and build instructions were written for the old pydocmd v2/v3 CLI, which is no longer compatible with pydoc-markdown v4.

Changes:

- Replace pydocmd.yml with a new pydoc-markdown.yml in the v4 config format with updated class paths (mffpy.reader.Reader, mffpy.epoch.Epoch), valid glob patterns for member selection, and MkDocs renderer config
- Add make docs (builds to docs/html/) and make docs-serve (live preview with auto-reload) targets to the Makefile
- Update README install/build instructions to use the new commands
- Add docs/html/ to .gitignore since it's generated output
