### PR TITLE
fix: handling unknown tags in PNS

### DIFF
--- a/mffpy/tests/test_xml_files.py
+++ b/mffpy/tests/test_xml_files.py
@@ -195,6 +195,54 @@ def test_PNSSet_sensors(pns_set):
     assert isinstance(first['notch'], float)
 
 
+# A minimal PNSSet containing an unexpected `<conversion>` property, which is
+# not part of `PNSSet._sensor_type_converter`. See
+# https://github.com/BEL-Public/mffpy/issues/144
+PNSSET_WITH_UNKNOWN_TAG = b"""<?xml version="1.0" encoding="UTF-8" ?>
+<PNSSet xmlns="http://www.egi.com/pnsSet_mff"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <name>Physio 16 set 60hz 1.0</name>
+    <ampSeries>400</ampSeries>
+    <sensors>
+        <sensor>
+            <name>ECG</name>
+            <number>0</number>
+            <unit>uV</unit>
+            <samplingRate>0</samplingRate>
+            <sensorType>ECG</sensorType>
+            <conversion>some-unexpected-value</conversion>
+            <color>0.0000,0.0000,0.0000,1.0000</color>
+            <positiveUp>false</positiveUp>
+        </sensor>
+    </sensors>
+</PNSSet>
+"""
+
+
+def test_PNSSet_unknown_property_is_kept_as_string():
+    """unexpected sensor properties should not crash parsing (issue #144)"""
+    with pytest.warns(UserWarning, match="conversion"):
+        pns_set = XML.from_file(BytesIO(PNSSET_WITH_UNKNOWN_TAG))
+        sensors = pns_set.sensors
+    sensor = sensors[0]
+    # the unknown tag is preserved verbatim as a raw string ...
+    assert sensor['conversion'] == 'some-unexpected-value'
+    # ... while known tags are still converted to their expected types
+    assert isinstance(sensor['number'], int)
+    assert isinstance(sensor['samplingRate'], float)
+
+
+def test_PNSSet_unknown_property_round_trips():
+    """unknown properties should also serialize back out without failing"""
+    with pytest.warns(UserWarning, match="conversion"):
+        sensors = XML.from_file(BytesIO(PNSSET_WITH_UNKNOWN_TAG)).sensors
+    from ..xml_files import PNSSet
+    content = PNSSet.content(
+        name='Physio 16 set 60hz 1.0', amp_series='400', sensors=sensors)
+    serialized_sensor = content['sensors']['text']['sensor'][0]['text']
+    assert serialized_sensor['conversion']['text'] == 'some-unexpected-value'
+
+
 def test_FileInfo(file_info):
     assert file_info.mffVersion == '3'
     assert file_info.acquisitionVersion == '5.4.1.2 (r28337)'

--- a/mffpy/xml_files.py
+++ b/mffpy/xml_files.py
@@ -1428,14 +1428,12 @@ class PNSSet(XML):
         ans = {}
         for e in el:
             tag = self.nsstrip(e.tag)
-            converter = self._sensor_type_converter.get(tag)
-            if converter is None:
+            converter = self._sensor_type_converter.get(tag, str)
+            if tag not in self._sensor_type_converter:
                 # Unknown property: keep its raw text rather than failing so
                 # that newer/unexpected PNSSet schemas can still be read.
                 warnings.warn(f"Unknown PNS sensor property '{tag}'; "
-                              "keeping its value as a raw string.")
-                converter = str
-            ans[tag] = converter(e.text)
+                              "keeping its value as a raw string.", UserWarning, stacklevel=2)
         return ans['number'], ans
 
     @cached_property

--- a/mffpy/xml_files.py
+++ b/mffpy/xml_files.py
@@ -1432,8 +1432,11 @@ class PNSSet(XML):
             if tag not in self._sensor_type_converter:
                 # Unknown property: keep its raw text rather than failing so
                 # that newer/unexpected PNSSet schemas can still be read.
-                warnings.warn(f"Unknown PNS sensor property '{tag}'; "
-                              "keeping its value as a raw string.", UserWarning, stacklevel=2)
+                warnings.warn(
+                    f"Unknown PNS sensor property '{tag}'; "
+                    "keeping its value as a raw string.",
+                    UserWarning, stacklevel=2)
+            ans[tag] = converter(e.text)
         return ans['number'], ans
 
     @cached_property

--- a/mffpy/xml_files.py
+++ b/mffpy/xml_files.py
@@ -1428,7 +1428,14 @@ class PNSSet(XML):
         ans = {}
         for e in el:
             tag = self.nsstrip(e.tag)
-            ans[tag] = self._sensor_type_converter[tag](e.text)
+            converter = self._sensor_type_converter.get(tag)
+            if converter is None:
+                # Unknown property: keep its raw text rather than failing so
+                # that newer/unexpected PNSSet schemas can still be read.
+                warnings.warn(f"Unknown PNS sensor property '{tag}'; "
+                              "keeping its value as a raw string.")
+                converter = str
+            ans[tag] = converter(e.text)
         return ans['number'], ans
 
     @cached_property
@@ -1463,11 +1470,11 @@ class PNSSet(XML):
         for sensor in sensors.values():
             formatted = {}
             for k, v in sensor.items():
-                assert k in cls._sensor_type_reverter, "sensor property "
-                f"'{k}' not serializable. Needs to be on of "
-                "{list(cls._sensor_type_reverter.keys())}"
+                # Fall back to ``str`` for unknown properties so that
+                # newer/unexpected PNSSet schemas can still round-trip.
+                reverter = cls._sensor_type_reverter.get(k, str)
                 formatted[k] = {
-                    TEXT: cls._sensor_type_reverter[k](v)  # type: ignore
+                    TEXT: reverter(v)  # type: ignore
                 }
             formatted_sensors.append({TEXT: formatted})
         return {


### PR DESCRIPTION
Addressing #144 by @PragnyaKhandelwal.

Still not sure what `conversion` really means / does as a PNS tag. Here's a more general fix to `warn` on unknown things and read them as strings. 

I like this approach because it allows you to still use the value if you want, albeit with a warning. 

```
pns = XML.from_file("…/pnsSet.xml")
raw = pns.sensors[3]['conversion']   # '2' (str, with the warning)
value = int(raw)
```

@damian5710 , what are your thoughts? Can you weigh in on if you want `conversion` officially added as well? 